### PR TITLE
Invoke-MalDoc Module

### DIFF
--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -1,0 +1,36 @@
+# Maldoc Handler
+# This function uses COM objects to emulate the creation and execution of malicious office documents
+
+function Invoke-MalDoc($macro_code, $office_version, $office_product) {
+    
+    $macro_code = "Sub Test()`n" + $macro_code + "`nEnd Sub"    
+    
+    if ($office_product -eq "Word") {
+        Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$office_version\Word\Security\" -Name 'AccessVBOM' -Value 1
+        
+        $word = New-Object -ComObject "Word.Application"
+        $doc = $word.Documents.Add()
+       
+        $word.ActiveDocument.VBProject.VBComponents.Add(1)
+        $word.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macro_code)
+
+        $word.Run("Test")
+        $doc.Close(0)
+    }
+    elseif ($office_product -eq "Excel") {
+        Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$office_version\Excel\Security\" -Name 'AccessVBOM' -Value 1
+        
+        $excel = New-Object -ComObject "Excel.Application"
+        $excel.Workbooks.Add()
+        
+        $excel.VBE.ActiveVBProject.VBComponents.Add(1)
+        $excel.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macro_code)
+        
+        $excel.Run("Test")
+        $excel.DisplayAlerts = $False
+        $excel.Quit()
+    }
+    else {
+        Write-Host -ForegroundColor Red "$office_product not supported"
+    }
+}


### PR DESCRIPTION
This function was written to decrease overhead in developing Atomics for maldoc behavior.

It uses COM objects to execute and create VB macros inside of Office Documents (Word and Excel Support) without the need to create a .docm or .xlsm

I've attached a test atomic that utilizes this module. Once this is available in Invoke-AtomicRedTeam I will use IEX (iwr "web address to Invoke-MalDoc") to load the function into the atomic instance of powershell

This was tested using windows 10 MSOffice version 16.0.