### PR TITLE
Add option to be prompted for InputArgs

### DIFF
--- a/Private/Replace-InputArgs.ps1
+++ b/Private/Replace-InputArgs.ps1
@@ -34,7 +34,7 @@ function Invoke-PromptForInputArgs([hashtable]$ip) {
     $InputArgs = @{ }
     foreach ($key in $ip.Keys) {
         $InputArgs[$key] = $ip[$key].default
-        $newValue = Read-Host -Prompt "Enter a value for $key, or press enter to accept the default [$($ip[$key].default)]"
+        $newValue = Read-Host -Prompt "Enter a value for $key , or press enter to accept the default.`n$($ip[$key].description.trim()) [$($ip[$key].default.trim())]"
         # replace default with user supplied
         if (-not [string]::IsNullOrWhiteSpace($newValue)) {
             $InputArgs.set_Item($key, $newValue)

--- a/Private/Replace-InputArgs.ps1
+++ b/Private/Replace-InputArgs.ps1
@@ -28,4 +28,17 @@ function Merge-InputArgs($finalCommand, $test, $customInputArgs, $PathToAtomicsF
     $finalCommand = ($finalCommand -replace "\`$PathToAtomicsFolder", $PathToAtomicsFolder) -replace "PathToAtomicsFolder", $PathToAtomicsFolder
 
     $finalCommand
-}           
+}
+
+function Invoke-PromptForInputArgs([hashtable]$ip) {
+    $InputArgs = @{ }
+    foreach ($key in $ip.Keys) {
+        $InputArgs[$key] = $ip[$key].default
+        $newValue = Read-Host -Prompt "Enter a value for $key, or press enter to accept the default [$($ip[$key].default)]"
+        # replace default with user supplied
+        if (-not [string]::IsNullOrWhiteSpace($newValue)) {
+            $InputArgs.set_Item($key, $newValue)
+        }
+    }
+    $InputArgs
+}

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -68,6 +68,12 @@ function Invoke-AtomicTest {
             ValueFromPipelineByPropertyName = $true,
             ParameterSetName = 'technique')]
         [switch]
+        $PromptForInputArgs = $false,
+
+        [Parameter(Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = 'technique')]
+        [switch]
         $GetPrereqs = $false,
 
         [Parameter(Mandatory = $false,
@@ -177,12 +183,17 @@ function Invoke-AtomicTest {
                     }
 
                     $testId = "$AT-$testCount $($test.name)"
-                    if ($ShowDetails) {
-                        Show-Details $test $testCount $technique $InputArgs $PathToAtomicsFolder
+                    if ($ShowDetailsBrief) {
+                        Write-KeyValue $testId
                         continue
                     }
-                    if($ShowDetailsBrief){
-                        Write-KeyValue $testId
+
+                    if ($PromptForInputArgs) {
+                        $InputArgs = Invoke-PromptForInputArgs $test.input_arguments
+                    }
+
+                    if ($ShowDetails) {
+                        Show-Details $test $testCount $technique $InputArgs $PathToAtomicsFolder
                         continue
                     }
 
@@ -202,7 +213,7 @@ function Invoke-AtomicTest {
                             $description = (Merge-InputArgs $dep.description $test $InputArgs $PathToAtomicsFolder).trim()
                             Write-KeyValue  "Attempting to satisfy prereq: " $description
                             $final_command_prereq = Merge-InputArgs $dep.prereq_command $test $InputArgs $PathToAtomicsFolder
-                            if($executor -ne "powershell") { $final_command_prereq = ($final_command_prereq.trim()).Replace("`n", " && ") }
+                            if ($executor -ne "powershell") { $final_command_prereq = ($final_command_prereq.trim()).Replace("`n", " && ") }
                             $final_command_get_prereq = Merge-InputArgs $dep.get_prereq_command $test $InputArgs $PathToAtomicsFolder
                             $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds
 


### PR DESCRIPTION
Specifying nondefault inputs can be done by passing in a hashtable, which is nice for scripts, but not very user friendly for one-off manual invocations of a test using non-default input args.

Now you can add the "-PromptForInputArgs" switch to interactively set custom input args.