### PR TITLE
Invoke a test on a remote system through a PSSession

### DIFF
--- a/Private/Invoke-CheckPrereqs.ps1
+++ b/Private/Invoke-CheckPrereqs.ps1
@@ -1,6 +1,6 @@
 function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomicsFolder, $TimeoutSeconds, $session = $null) {
     $FailureReasons = New-Object System.Collections.ArrayList
-    if (-not $session -or ($test.executor.elevation_required -and -not $isElevated)) {
+    if (-not $session -and ($test.executor.elevation_required -and -not $isElevated)) {
         $FailureReasons.add("Elevation required but not provided`n") | Out-Null
     }
     foreach ($dep in $test.dependencies) {

--- a/Private/Invoke-CheckPrereqs.ps1
+++ b/Private/Invoke-CheckPrereqs.ps1
@@ -1,4 +1,4 @@
-function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomicsFolder, $TimeoutSeconds) {
+function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomicsFolder, $TimeoutSeconds, $session = $null) {
     $FailureReasons = New-Object System.Collections.ArrayList
     if ($test.executor.elevation_required -and -not $isElevated) {
         $FailureReasons.add("Elevation required but not provided`n") | Out-Null
@@ -7,7 +7,7 @@ function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomi
         $executor = Get-PrereqExecutor $test
         $final_command = Merge-InputArgs $dep.prereq_command $test $customInputArgs $PathToAtomicsFolder
         if($executor -ne "powershell") { $final_command = ($final_Command.trim()).Replace("`n", " && ") }
-        $res = Invoke-ExecuteCommand $final_command $executor $TimeoutSeconds
+        $res = Invoke-ExecuteCommand $final_command $executor $TimeoutSeconds  $session
         $description = Merge-InputArgs $dep.description $test $customInputArgs $PathToAtomicsFolder
         if ($res -ne 0) {
             $FailureReasons.add($description) | Out-Null

--- a/Private/Invoke-CheckPrereqs.ps1
+++ b/Private/Invoke-CheckPrereqs.ps1
@@ -1,6 +1,6 @@
 function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomicsFolder, $TimeoutSeconds, $session = $null) {
     $FailureReasons = New-Object System.Collections.ArrayList
-    if ($test.executor.elevation_required -and -not $isElevated) {
+    if (-not $session -or ($test.executor.elevation_required -and -not $isElevated)) {
         $FailureReasons.add("Elevation required but not provided`n") | Out-Null
     }
     foreach ($dep in $test.dependencies) {

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -24,6 +24,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $scriptParentPath = Split-Path $import -Parent
             $fp = Join-Path $scriptParentPath "Invoke-Process.ps1"
             $fp2 = Join-Path $scriptParentPath "Invoke-KillProcessTree.ps1"
+            #need maldoc file and verifyfilehash
             invoke-command -Session $session -FilePath $fp
             invoke-command -Session $session -FilePath $fp2
             invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds }

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -26,7 +26,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $fp2 = Join-Path $scriptParentPath "Invoke-KillProcessTree.ps1"
             invoke-command -Session $session -FilePath $fp
             invoke-command -Session $session -FilePath $fp2
-            $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile $env:temp\art-out.txt }
+            $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile $env:temp\art-out.txt -stderrFile $env:temp\art-err.txt  }
         }
         else {
             $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds  

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -1,6 +1,6 @@
-function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds) {
+function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $session = $null) {
     $null = @( 
-        if($null -eq $finalCommand){return 0}
+        if ($null -eq $finalCommand) { return 0 }
         $finalCommand = $finalCommand.trim()
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
@@ -8,18 +8,32 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds) {
             $execPrefix = "-c"
             $execExe = $executor
             if ($executor -eq "command_prompt") { $execPrefix = "/c"; $execExe = "cmd.exe" }
-            $res = Invoke-Process -filename $execExe -Arguments "$execPrefix `"$execCommand`"" -TimeoutSeconds $TimeoutSeconds                
+            $arguments = "$execPrefix `"$execCommand`"" 
         }
         elseif ($executor -eq "powershell") {
             $execCommand = $finalCommand -replace "`"", "`\`"`""
             $execExe = "powershell.exe"; if ($IsLinux -or $IsMacOS) { $execExe = "pwsh" }
-            $res = Invoke-Process -filename $execExe -Arguments "& {$execCommand}" -TimeoutSeconds $TimeoutSeconds
-                      
+            $arguments = "& {$execCommand}"   
         }
         else { 
             Write-Warning -Message "Unable to generate or execute the command line properly. Unknown executor"
             $res = -1
+            return $res
         }
+        if ($session) {
+            $scriptParentPath = Split-Path $import -Parent
+            $fp = Join-Path $scriptParentPath "Invoke-Process.ps1"
+            $fp2 = Join-Path $scriptParentPath "Invoke-KillProcessTree.ps1"
+            invoke-command -Session $session -FilePath $fp
+            invoke-command -Session $session -FilePath $fp2
+            write-host $arguments
+            invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds }
+        }
+        else {
+            write-host "here $arguments"
+            $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds  
+        }              
+
     )
     $res
 }

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -24,10 +24,9 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $scriptParentPath = Split-Path $import -Parent
             $fp = Join-Path $scriptParentPath "Invoke-Process.ps1"
             $fp2 = Join-Path $scriptParentPath "Invoke-KillProcessTree.ps1"
-            #need maldoc file and verifyfilehash
             invoke-command -Session $session -FilePath $fp
             invoke-command -Session $session -FilePath $fp2
-            invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds }
+            $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile $env:temp\art-out.txt }
         }
         else {
             $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds  

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -26,11 +26,9 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $fp2 = Join-Path $scriptParentPath "Invoke-KillProcessTree.ps1"
             invoke-command -Session $session -FilePath $fp
             invoke-command -Session $session -FilePath $fp2
-            write-host $arguments
             invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds }
         }
         else {
-            write-host "here $arguments"
             $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds  
         }              
 

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -14,7 +14,10 @@ function Invoke-Process {
         [Int]$TimeoutSeconds = 120,
 
         [Parameter(Mandatory = $false, Position =4)]
-        [String]$stdoutFile = $null
+        [String]$stdoutFile = $null,
+
+        [Parameter(Mandatory = $false, Position =5)]
+        [String]$stderrFile = $null
     )
 
     end {
@@ -22,8 +25,8 @@ function Invoke-Process {
         try {
             # new Process
             if ($stdoutFile) {
-                Remove-Item $stdoutFile -Force -ErrorAction Ignore
-                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput $stdoutFile
+                Remove-Item $stdoutFile -Force -ErrorAction Ignore; Remove-Item $stderrFile -Force -ErrorAction Ignore
+                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
              }
             else {
                 $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -10,14 +10,12 @@ function Invoke-Process {
         [Parameter(Mandatory = $false, Position = 1)]
         [string]$Arguments = "",
         
-        [Parameter(Mandatory = $false, Position = 2)]
-        [string]$WorkingDirectory = $( if ($IsLinux -or $IsMacOS) {"/tmp" } else { $env:TEMP }),
-
         [Parameter(Mandatory = $false, Position = 3)]
         [Int]$TimeoutSeconds = 120
     )
 
     end {
+        $WorkingDirectory = if ($IsLinux -or $IsMacOS) {"/tmp" } else { $env:TEMP }
         try {
             # new Process
             $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -11,14 +11,23 @@ function Invoke-Process {
         [string]$Arguments = "",
         
         [Parameter(Mandatory = $false, Position = 3)]
-        [Int]$TimeoutSeconds = 120
+        [Int]$TimeoutSeconds = 120,
+
+        [Parameter(Mandatory = $false, Position =4)]
+        [String]$stdoutFile = $null
     )
 
     end {
-        $WorkingDirectory = if ($IsLinux -or $IsMacOS) {"/tmp" } else { $env:TEMP }
+        $WorkingDirectory = if ($IsLinux -or $IsMacOS) { "/tmp" } else { $env:TEMP }
         try {
             # new Process
-            $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru
+            if ($stdoutFile) {
+                Remove-Item $stdoutFile -Force -ErrorAction Ignore
+                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput $stdoutFile
+             }
+            else {
+                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru
+            }
             $handle = $process.Handle # cache process.Handle, otherwise ExitCode is null from powershell processes
 
             # wait for complete

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -207,14 +207,14 @@ function Invoke-AtomicTest {
                             $final_command_prereq = Merge-InputArgs $dep.prereq_command $test $InputArgs $PathToAtomicsFolder
                             if($executor -ne "powershell") { $final_command_prereq = ($final_command_prereq.trim()).Replace("`n", " && ") }
                             $final_command_get_prereq = Merge-InputArgs $dep.get_prereq_command $test $InputArgs $PathToAtomicsFolder
-                            $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds
+                            $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds $session
 
                             if ($res -eq 0) {
                                 Write-KeyValue "Prereq already met: " $description
                             }
                             else {
-                                $res = Invoke-ExecuteCommand $final_command_get_prereq $executor $TimeoutSeconds 
-                                $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds
+                                $res = Invoke-ExecuteCommand $final_command_get_prereq $executor $TimeoutSeconds $session
+                                $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds $session
                                 if ($res -eq 0) {
                                     Write-KeyValue "Prereq successfully met: " $description
                                 }
@@ -230,7 +230,7 @@ function Invoke-AtomicTest {
                     elseif ($Cleanup) {
                         Write-KeyValue "Executing cleanup for test: " $testId
                         $final_command = Merge-InputArgs $test.executor.cleanup_command $test $InputArgs $PathToAtomicsFolder
-                        $res = Invoke-ExecuteCommand $final_command $test.executor.name $TimeoutSeconds
+                        $res = Invoke-ExecuteCommand $final_command $test.executor.name $TimeoutSeconds $session
                         Write-KeyValue "Done executing cleanup for test: " $testId
                     }
                     else {

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -107,7 +107,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $PathToPayloads = $( if ($Session) { invoke-command -Session $Session -ScriptBlock {$Env:TEMP} } else { $PathToAtomicsFolder })
+        $PathToPayloads = $( if ($Session) { invoke-command -Session $Session -ScriptBlock {"$Env:TEMP\AtomicRedTeam"} } else { $PathToAtomicsFolder })
     )
     BEGIN { } # Intentionally left blank and can be removed
     PROCESS {

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -238,6 +238,7 @@ function Invoke-AtomicTest {
                         $startTime = get-date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToAtomicsFolder
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
+                        if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content $env:temp\art-out.txt }) }
                         Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds
                         Write-KeyValue "Done executing test: " $testId
                     }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -194,7 +194,7 @@ function Invoke-AtomicTest {
 
                     if ($CheckPrereqs) {
                         Write-KeyValue "CheckPrereq's for: " $testId
-                        $failureReasons = Invoke-CheckPrereqs $test $isElevated $InputArgs $PathToAtomicsFolder $TimeoutSeconds
+                        $failureReasons = Invoke-CheckPrereqs $test $isElevated $InputArgs $PathToAtomicsFolder $TimeoutSeconds $session
                         Write-PrereqResults $FailureReasons $testId
                     }
                     elseif ($GetPrereqs) {

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -99,7 +99,10 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [Int]
-        $TimeoutSeconds = 120
+        $TimeoutSeconds = 120,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'technique')]
+        [System.Management.Automation.Runspaces.PSSession[]]$Session
     )
     BEGIN { } # Intentionally left blank and can be removed
     PROCESS {
@@ -234,7 +237,7 @@ function Invoke-AtomicTest {
                         Write-KeyValue "Executing test: " $testId
                         $startTime = get-date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToAtomicsFolder
-                        $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds
+                        $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
                         Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds
                         Write-KeyValue "Done executing test: " $testId
                     }
@@ -265,3 +268,5 @@ function Invoke-AtomicTest {
     } # End of PROCESS block
     END { } # Intentionally left blank and can be removed
 }
+# $session = New-PSSession -Credential nti\croberts -ComputerName "atomicsoc06"
+# Invoke-AtomicTest t1003 -TestNumbers 11 -Session $session

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -228,7 +228,7 @@ function Invoke-AtomicTest {
                                 }
                             }
                         }
-                        if ($test.executor.elevation_required -and -not $isElevated) {
+                        if (-not $session -and $test.executor.elevation_required -and -not $isElevated) {
                             Write-Host -ForegroundColor Red "Elevation required but not provided"
                         }
                     }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -107,7 +107,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $PathToPayloads = $( if ($Session) { invoke-command -Session $admin -ScriptBlock {$env:temp} } else { $PathToAtomicsFolder })
+        $PathToPayloads = $( if ($Session) { invoke-command -Session $Session -ScriptBlock {$Env:TEMP} } else { $PathToAtomicsFolder })
     )
     BEGIN { } # Intentionally left blank and can be removed
     PROCESS {

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -107,7 +107,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $PathToPayloads = $( if ($Session) { "`$Env:TEMP\AtomicRedTeam" } else { $PathToAtomicsFolder })
+        $PathToPayloads = $( if ($Session) { invoke-command -Session $admin -ScriptBlock {$env:temp} } else { $PathToAtomicsFolder })
     )
     BEGIN { } # Intentionally left blank and can be removed
     PROCESS {

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -274,5 +274,3 @@ function Invoke-AtomicTest {
     } # End of PROCESS block
     END { } # Intentionally left blank and can be removed
 }
-# $session = New-PSSession -Credential nti\croberts -ComputerName "atomicsoc06"
-# Invoke-AtomicTest t1003 -TestNumbers 11 -Session $session


### PR DESCRIPTION
Invoke-AtomicTest now supports the `-Session` parameter for invoking an atomic on a remote machine.

On the remote machine you must have PS remoting enabled (`Enable-PSRemoting`) and for simplicity sake, the user you remote as should be an admin (although there are ways to do it with a non-admin user).  Create the session with `$sess = New-PSSession -ComputerName somecomputer -Credential mydomain\username` , enter the credentials when prompted and then pass the session to Invoke-AtomicTest `Invoke-AtomicTest T1003 -TestNumbers 1 -Session $sess` .  If the test requires supporting files, such as those in the T#\bin or T#\src directories, those can be made available to the remote machine using the `-GetPrereqs` flag. 