### PR TITLE
tmp is default location for exec log

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -90,7 +90,7 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $ExecutionLogPath = "Invoke-AtomicTest-ExecutionLog.csv",
+        $ExecutionLogPath = $( if ($IsLinux -or $IsMacOS) { "/tmp/Invoke-AtomicTest-ExecutionLog.csv" } else { "$env:TEMP\Invoke-AtomicTest-ExecutionLog.csv" }),
 
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]


### PR DESCRIPTION
execution log used to be written to the "current directory" which was inconsistent and problematic if the user did not have write access to the current directory. This PR sets the default exec log location to the temp directory. (/tmp on Linux and Mac or $env:Temp on Windows). Of course, the `-ExecutionLogPath` parameter can still be specified to set a custom path/filename for the exec log.

Tested on:
Ubuntu 18.04
Windows 10 Powershell Version 5