### PR TITLE
Cross platform remote exec

### DIFF
--- a/Private/Get-TargetInfo.ps1
+++ b/Private/Get-TargetInfo.ps1
@@ -4,7 +4,7 @@ function Get-TargetInfo($Session) {
     $targetHostname = hostname
     $targetUser = whoami
     if ($Session) {
-        $targetPlatform, $isElevated, $tmpDir = invoke-command -Session $Session -ScriptBlock {
+        $targetPlatform, $isElevated, $tmpDir, $targetHostname, $targetUser = invoke-command -Session $Session -ScriptBlock {
             $targetPlatform = "windows"
             $tmpDir = "/tmp/"
             $targetHostname = hostname
@@ -12,7 +12,7 @@ function Get-TargetInfo($Session) {
             if ($IsLinux) { $targetPlatform = "linux" }
             elseif ($IsMacOS) { $targetPlatform =  "macos" }
             else {  # windows
-                $tmpDir = $env:TEMP
+                $tmpDir = "$env:TEMP\"
                 $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
             }
             if ($IsLinux -or $IsMacOS) {

--- a/Private/Get-TargetInfo.ps1
+++ b/Private/Get-TargetInfo.ps1
@@ -1,10 +1,14 @@
 function Get-TargetInfo($Session) {
-    $tmpDir = $env:TEMP
+    $tmpDir = "$env:TEMP\"
     $isElevated = $false
+    $targetHostname = hostname
+    $targetUser = whoami
     if ($Session) {
         $targetPlatform, $isElevated, $tmpDir = invoke-command -Session $Session -ScriptBlock {
             $targetPlatform = "windows"
-            $tmpDir = "/tmp"
+            $tmpDir = "/tmp/"
+            $targetHostname = hostname
+            $targetUser = whoami
             if ($IsLinux) { $targetPlatform = "linux" }
             elseif ($IsMacOS) { $targetPlatform =  "macos" }
             else {  # windows
@@ -16,13 +20,13 @@ function Get-TargetInfo($Session) {
                 $privid = id -u                
                 if ($privid -eq 0) { $isElevated = $true }
             }
-            $targetPlatform, $isElevated, $tmpDir
+            $targetPlatform, $isElevated, $tmpDir, $targetHostname, $targetUser
         } # end ScriptBlock for remote session
     }
     else {
         $targetPlatform = "linux"
         if ($IsLinux -or $IsMacOS) {
-            $tmpDir = "/tmp"
+            $tmpDir = "/tmp/"
             $isElevated = $false
             $privid = id -u                
             if ($privid -eq 0) { $isElevated = $true }
@@ -35,5 +39,5 @@ function Get-TargetInfo($Session) {
         }
       
     }
-    $targetPlatform, $isElevated, $tmpDir
+    $targetPlatform, $isElevated, $tmpDir, $targetHostname, $targetUser
 } 

--- a/Private/Get-TargetInfo.ps1
+++ b/Private/Get-TargetInfo.ps1
@@ -1,0 +1,39 @@
+function Get-TargetInfo($Session) {
+    $tmpDir = $env:TEMP
+    $isElevated = $false
+    if ($Session) {
+        $targetPlatform, $isElevated, $tmpDir = invoke-command -Session $Session -ScriptBlock {
+            $targetPlatform = "windows"
+            $tmpDir = "/tmp"
+            if ($IsLinux) { $targetPlatform = "linux" }
+            elseif ($IsMacOS) { $targetPlatform =  "macos" }
+            else {  # windows
+                $tmpDir = $env:TEMP
+                $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+            }
+            if ($IsLinux -or $IsMacOS) {
+                $isElevated = $false
+                $privid = id -u                
+                if ($privid -eq 0) { $isElevated = $true }
+            }
+            $targetPlatform, $isElevated, $tmpDir
+        } # end ScriptBlock for remote session
+    }
+    else {
+        $targetPlatform = "linux"
+        if ($IsLinux -or $IsMacOS) {
+            $tmpDir = "/tmp"
+            $isElevated = $false
+            $privid = id -u                
+            if ($privid -eq 0) { $isElevated = $true }
+            $isElevated
+            if ($IsMacOS) { $targetPlatform = "macos" }
+        }
+        else {
+            $targetPlatform = "windows"
+            $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        }
+      
+    }
+    $targetPlatform, $isElevated, $tmpDir
+} 

--- a/Private/Invoke-CheckPrereqs.ps1
+++ b/Private/Invoke-CheckPrereqs.ps1
@@ -1,6 +1,6 @@
 function Invoke-CheckPrereqs ($test, $isElevated, $customInputArgs, $PathToAtomicsFolder, $TimeoutSeconds, $session = $null) {
     $FailureReasons = New-Object System.Collections.ArrayList
-    if (-not $session -and ($test.executor.elevation_required -and -not $isElevated)) {
+    if ( $test.executor.elevation_required -and -not $isElevated) {
         $FailureReasons.add("Elevation required but not provided`n") | Out-Null
     }
     foreach ($dep in $test.dependencies) {

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -26,7 +26,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $fp2 = Join-Path $scriptParentPath "Invoke-KillProcessTree.ps1"
             invoke-command -Session $session -FilePath $fp
             invoke-command -Session $session -FilePath $fp2
-            $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile $env:temp\art-out.txt -stderrFile $env:temp\art-err.txt  }
+            $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile "art-out.txt" -stderrFile "art-err.txt"  }
         }
         else {
             $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds  

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -25,8 +25,7 @@ function Invoke-Process {
         try {
             # new Process
             if ($stdoutFile) {
-                Remove-Item $stdoutFile -Force -ErrorAction Ignore; Remove-Item $stderrFile -Force -ErrorAction Ignore
-                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
+                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput (Join-Path $WorkingDirectory $stdoutFile) -RedirectStandardError (Join-Path $WorkingDirectory $stderrFile)
              }
             else {
                 $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru

--- a/Private/Write-ExecutionLog.ps1
+++ b/Private/Write-ExecutionLog.ps1
@@ -1,4 +1,4 @@
-function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPath $targetHostname, $targetUser) {
+function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPath, $targetHostname, $targetUser) {
     if (!(Test-Path $logPath)) { 
         New-Item $logPath -Force -ItemType File | Out-Null
     } 

--- a/Private/Write-ExecutionLog.ps1
+++ b/Private/Write-ExecutionLog.ps1
@@ -1,11 +1,9 @@
-function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPath) {
+function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPath $targetHostname, $targetUser) {
     if (!(Test-Path $logPath)) { 
         New-Item $logPath -Force -ItemType File | Out-Null
     } 
 
     $timeUTC = (Get-Date($startTime).toUniversalTime() -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $timeLocal = (Get-Date($startTime) -uformat "%Y-%m-%dT%H:%M:%S").ToString()
-    $ArtHostname = hostname
-    $ArtUser = whoami
-    [PSCustomObject][ordered]@{ "Execution Time (UTC)" = $timeUTC; "Execution Time (Local)" = $timeLocal; "Technique" = $technique; "Test Number" = $testNum; "Test Name" = $testName; "Hostname" = $ArtHostname; "Username" = $ArtUser } | Export-Csv -Path $LogPath -NoTypeInformation -Append
+    [PSCustomObject][ordered]@{ "Execution Time (UTC)" = $timeUTC; "Execution Time (Local)" = $timeLocal; "Technique" = $technique; "Test Number" = $testNum; "Test Name" = $testName; "Hostname" = $targetHostname; "Username" = $targetUser } | Export-Csv -Path $LogPath -NoTypeInformation -Append
 }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -116,7 +116,7 @@ function Invoke-AtomicTest {
         Write-Verbose -Message 'Attempting to run Atomic Techniques'
         Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n"
         
-        $targetPlatform, $isElevated, $tmpDir = Get-TargetInfo $Session
+        $targetPlatform, $isElevated, $tmpDir, $targetHostname, $targetUser = Get-TargetInfo $Session
         $PathToPayloads = if ($Session) { "$tmpDir`AtomicRedTeam" }  else { $PathToAtomicsFolder }
 
         function Invoke-AtomicTestSingle ($AT) {
@@ -188,7 +188,7 @@ function Invoke-AtomicTest {
                     }
 
                     if ($ShowDetails) {
-                        Show-Details $test $testCount $technique $InputArgs $PathToAtomicsFolder
+                        Show-Details $test $testCount $technique $InputArgs $PathToPayloads
                         continue
                     }
 
@@ -241,8 +241,8 @@ function Invoke-AtomicTest {
                         $startTime = get-date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
-                        if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$Using:tmpDir`art-out.txt"; Get-Content "$Using:tmpDir`art-err.txt"; Remove-Item "$Using:tmpDir`art-out.txt", "$Using:tmpDir`art-err.txt" -Force -ErrorAction Ignore })}
-                        Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds $targetHostname $targetUser
+                        if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content $($Using:tmpDir + "art-out.txt"); Get-Content $($Using:tmpDir + "art-err.txt"); Remove-Item $($Using:tmpDir + "art-out.txt"), $($Using:tmpDir + "art-err.txt") -Force -ErrorAction Ignore })}
+                        Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $targetHostname $targetUser
                         Write-KeyValue "Done executing test: " $testId
                     }
  

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -117,7 +117,11 @@ function Invoke-AtomicTest {
         Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n"
         
         $targetPlatform, $isElevated, $tmpDir = Get-TargetInfo $Session
-        $PathToPayloads = if ($Session) { Join-Path $tmpDir "AtomicRedTeam" } else { $PathToAtomicsFolder }
+        $PathToPayloads = if ($Session) { if ($targetPlatform -eq "windows") { "$tmpDir\AtomicRedTeam" } else { "$tmpDir/AtomicRedTeam" } } else { $PathToAtomicsFolder }
+        Write-Host $targetPlatform
+        write-host $isElevated
+        write-host $tmpDir
+        write-host $PathToPayloads
 
         function Invoke-AtomicTestSingle ($AT) {
 
@@ -243,10 +247,10 @@ function Invoke-AtomicTest {
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
                         if ($session) { 
                             if ($targetPlatform -eq "windows") {
-                                write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$env:temp\art-out.txt"; Get-Content "$env:temp\art-err.txt";  Remove-Item "$env:temp\art-out.txt","$env:temp\art-err.txt" -Force -ErrorAction Ignore}) 
+                                write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$env:temp\art-out.txt"; Get-Content "$env:temp\art-err.txt"; Remove-Item "$env:temp\art-out.txt", "$env:temp\art-err.txt" -Force -ErrorAction Ignore }) 
                             }
                             else {
-                                write-output (Invoke-Command -Session $session -scriptblock { Get-Content "/tmp/art-out.txt"; Get-Content "/tmp/art-err.txt";  Remove-Item "/tmp/art-out.txt","/tmp/art-err.txt" -Force -ErrorAction Ignore}) 
+                                write-output (Invoke-Command -Session $session -scriptblock { Get-Content "/tmp/art-out.txt"; Get-Content "/tmp/art-err.txt"; Remove-Item "/tmp/art-out.txt", "/tmp/art-err.txt" -Force -ErrorAction Ignore }) 
                             }
                         }
                         Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -241,7 +241,7 @@ function Invoke-AtomicTest {
                         $startTime = get-date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
-                        if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$Using:tmpDir`art-out.txt"; Get-Content "$Using:tmpDir`art-err.txt"; Remove-Item "$Using:tmpDir`art-out.txt", "$Using:tmpDir`art-err.txt" -Force -ErrorAction Ignore }) 
+                        if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$Using:tmpDir`art-out.txt"; Get-Content "$Using:tmpDir`art-err.txt"; Remove-Item "$Using:tmpDir`art-out.txt", "$Using:tmpDir`art-err.txt" -Force -ErrorAction Ignore })}
                         Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds $targetHostname $targetUser
                         Write-KeyValue "Done executing test: " $testId
                     }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -117,11 +117,7 @@ function Invoke-AtomicTest {
         Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n"
         
         $targetPlatform, $isElevated, $tmpDir = Get-TargetInfo $Session
-        $PathToPayloads = if ($Session) { if ($targetPlatform -eq "windows") { "$tmpDir\AtomicRedTeam" } else { "$tmpDir/AtomicRedTeam" } } else { $PathToAtomicsFolder }
-        Write-Host $targetPlatform
-        write-host $isElevated
-        write-host $tmpDir
-        write-host $PathToPayloads
+        $PathToPayloads = if ($Session) { "$tmpDir`AtomicRedTeam" }  else { $PathToAtomicsFolder }
 
         function Invoke-AtomicTestSingle ($AT) {
 
@@ -245,15 +241,8 @@ function Invoke-AtomicTest {
                         $startTime = get-date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
-                        if ($session) { 
-                            if ($targetPlatform -eq "windows") {
-                                write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$env:temp\art-out.txt"; Get-Content "$env:temp\art-err.txt"; Remove-Item "$env:temp\art-out.txt", "$env:temp\art-err.txt" -Force -ErrorAction Ignore }) 
-                            }
-                            else {
-                                write-output (Invoke-Command -Session $session -scriptblock { Get-Content "/tmp/art-out.txt"; Get-Content "/tmp/art-err.txt"; Remove-Item "/tmp/art-out.txt", "/tmp/art-err.txt" -Force -ErrorAction Ignore }) 
-                            }
-                        }
-                        Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds
+                        if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content "$Using:tmpDir`art-out.txt"; Get-Content "$Using:tmpDir`art-err.txt"; Remove-Item "$Using:tmpDir`art-out.txt", "$Using:tmpDir`art-err.txt" -Force -ErrorAction Ignore }) 
+                        Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $TimeoutSeconds $targetHostname $targetUser
                         Write-KeyValue "Done executing test: " $testId
                     }
  


### PR DESCRIPTION
This PR makes execution of atomic tests against a remote machine using the `-Session` parameter work cross-platform (where the remote machine can be Windows, Linux, or OSx).  The following table defines the prerequisites to make this work, where the "Local Computer" is the one where Invoke-AtomicRedTeam is installed and the "Remote Computer" is where the atomics will be executed.

![image](https://user-images.githubusercontent.com/22311332/76806831-23bd5a00-67a8-11ea-8feb-09faf0e6f96a.png)

See this link for instructions on configuring PowerShell Remoting over SSH:
https://docs.microsoft.com/en-us/powershell/scripting/learn/remoting/ssh-remoting-in-powershell-core?view=powershell-7

See this link for enabling PS Remoting:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enable-psremoting?view=powershell-7
Note: see the "-SkipNetworkProfileCheck" option if your client is on a public network

To run atomics that require admin privs on a remote linux/OSx machine you would need to establish the PSSession as root until this issue is resolved: (Can't run sudo in a PSSession) https://github.com/PowerShell/PowerShell/issues/11970

Testing:
Ubuntu 18.04
Windows 10 Powershell Version 5
Windows 10 Powershell Core
Mac OSx Mojave