### PR TITLE
show T# correctly

### DIFF
--- a/Private/Show-Details.ps1
+++ b/Private/Show-Details.ps1
@@ -1,6 +1,6 @@
 function Show-Details ($test, $testCount, $technique, $customInputArgs, $PathToAtomicsFolder) {
     # Header info
-    $tName = $technique.display_name.ToString() + " " + $technique.attack_technique.ToString() 
+    $tName = $technique.display_name.ToString() + " " + $technique.attack_technique 
     Write-KeyValue "[********BEGIN TEST*******]`nTechnique: "  $tName
     Write-KeyValue "Atomic Test Name: " $test.name.ToString()
     Write-KeyValue "Atomic Test Number: " $testCount


### PR DESCRIPTION
Show Details was printing the test name with a weird string at the end instead of the Technique number that was intended to be printed. 

![image](https://user-images.githubusercontent.com/22311332/77030880-90ca1e80-6965-11ea-8e08-15a5a89f64d8.png)
