### PR TITLE
fix for macos,linux

### DIFF
--- a/Private/Get-TargetInfo.ps1
+++ b/Private/Get-TargetInfo.ps1
@@ -30,7 +30,6 @@ function Get-TargetInfo($Session) {
             $isElevated = $false
             $privid = id -u                
             if ($privid -eq 0) { $isElevated = $true }
-            $isElevated
             if ($IsMacOS) { $targetPlatform = "macos" }
         }
         else {


### PR DESCRIPTION
Get-TargetInfo wasn't working for local execution on MacOs and Linux, which was completely breaking invoke-atomictest for these OS's