### PR TITLE
cleaner show details

### DIFF
--- a/Private/Show-Details.ps1
+++ b/Private/Show-Details.ps1
@@ -1,13 +1,18 @@
+function Invoke-CleanupDescription(){
+    $ret1 = $test.description.ToString().trim() -replace '(?<!\n)\n(?!\n)', ' ' #replace single linefeeds with a space
+    $ret1 -replace '\n\n', "`n" #replace double linefeeds with a single linefeed
+}
 function Show-Details ($test, $testCount, $technique, $customInputArgs, $PathToAtomicsFolder) {
     # Header info
     $tName = $technique.display_name.ToString() + " " + $technique.attack_technique 
-    Write-KeyValue "[********BEGIN TEST*******]`nTechnique: "  $tName
+    Write-Host -ForegroundColor Magenta "[********BEGIN TEST*******]"
+    Write-KeyValue "Technique: "  $tName
     Write-KeyValue "Atomic Test Name: " $test.name.ToString()
     Write-KeyValue "Atomic Test Number: " $testCount
-    Write-KeyValue "Description: " $test.description.ToString().trim()
+    Write-KeyValue "Description: " $(Invoke-CleanupDescription $test)
 
     # Attack Commands
-    Write-Host -ForegroundColor Yellow "Attack Commands:"
+    Write-Host -ForegroundColor Yellow "`nAttack Commands:"
     $elevationRequired = $false
     if ($nul -ne $test.executor.elevation_required ) { $elevationRequired = $test.executor.elevation_required }
     $executor_name = $test.executor.name
@@ -19,7 +24,7 @@ function Show-Details ($test, $testCount, $technique, $customInputArgs, $PathToA
 
     # Cleanup Commands
     if ($nul -ne $test.executor.cleanup_command) {
-        Write-Host -ForegroundColor Yellow "Cleanup Commands:"
+        Write-Host -ForegroundColor Yellow "`nCleanup Commands:"
         $final_command = Merge-InputArgs $test.executor.cleanup_command $test $customInputArgs $PathToAtomicsFolder
         Write-KeyValue "Command:`n" $test.executor.cleanup_command.trim()
         if ($test.executor.cleanup_command -ne $final_command) { Write-KeyValue "Command (with inputs):`n" $final_command.trim() }
@@ -27,7 +32,7 @@ function Show-Details ($test, $testCount, $technique, $customInputArgs, $PathToA
 
     # Dependencies
     if ($nul -ne $test.dependencies) {
-        Write-Host -ForegroundColor Yellow "Dependencies:"
+        Write-Host -ForegroundColor Yellow "`nDependencies:"
         foreach ($dep in $test.dependencies) {
             $final_command_prereq = Merge-InputArgs $dep.prereq_command $test $customInputArgs $PathToAtomicsFolder
             $final_command_get_prereq = Merge-InputArgs $dep.get_prereq_command $test $customInputArgs $PathToAtomicsFolder
@@ -40,6 +45,6 @@ function Show-Details ($test, $testCount, $technique, $customInputArgs, $PathToA
         }
     }
     # Footer
-    Write-Host -Fore Cyan "[!!!!!!!!END TEST!!!!!!!]`n`n"
+    Write-Host -ForegroundColor Magenta "[!!!!!!!!END TEST!!!!!!!]`n`n"
 
 }

--- a/Private/Write-KeyValue.ps1
+++ b/Private/Write-KeyValue.ps1
@@ -1,16 +1,13 @@
 function Write-KeyValue ($key, $value) {
     Write-Host -ForegroundColor  Cyan -NoNewline $key
-
     $split = $value -split "(#{[a-z-_A-Z]*})"
     foreach ($s in $split){
         if($s -match "(#{[a-z-_A-Z]*})"){
             Write-Host -ForegroundColor Red -NoNewline $s
-
         }
         else {
             Write-Host -ForegroundColor Green -NoNewline $s
         }
     }
     Write-Host ""
-
 }

--- a/Private/Write-KeyValue.ps1
+++ b/Private/Write-KeyValue.ps1
@@ -1,4 +1,16 @@
 function Write-KeyValue ($key, $value) {
     Write-Host -ForegroundColor  Cyan -NoNewline $key
-    Write-Host -ForegroundColor Green $value
+
+    $split = $value -split "(#{[a-z-_A-Z]*})"
+    foreach ($s in $split){
+        if($s -match "(#{[a-z-_A-Z]*})"){
+            Write-Host -ForegroundColor Red -NoNewline $s
+
+        }
+        else {
+            Write-Host -ForegroundColor Green -NoNewline $s
+        }
+    }
+    Write-Host ""
+
 }


### PR DESCRIPTION
Show details output (-ShowDetails) was a little hard to read. This makes it a little easier with added colors, highlighting of input args in red and some extra spacing between sections. 

Tested on Win10 with PS and pwsh
Tested on MacOS