### PR TITLE
Invoke-WebRequestVerifyHash: add explicit support for TLS 1.1 & 1.2

### DIFF
--- a/Public/Invoke-WebRequestVerifyHash.ps1
+++ b/Public/Invoke-WebRequestVerifyHash.ps1
@@ -3,6 +3,7 @@ function Invoke-WebRequestVerifyHash ($url, $outfile, $hash) {
     $null = @( 
         New-Item -ItemType Directory (Split-Path $outfile) -Force | Out-Null
         $ms = New-Object IO.MemoryStream
+        [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12)
         (New-Object System.Net.WebClient).OpenRead($url).copyto($ms)
         $ms.seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
         $actualHash = (Get-FileHash -InputStream $ms).Hash 


### PR DESCRIPTION
Some .NET versions used even by modern PowerShell on Win10 do not enable by default TLS 1.2 (nor 1.1) which makes requests to strict servers fail.
For example to this URL:
https://github.com/redcanaryco/atomic-red-team/blob/14905c7a1618fe52bc0973ac575949ab4f9c2d67/atomics/T1003/T1003.yaml#L103
```
Invoke-AtomicTest T1003 -TestNumbers 3 -GetPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

GetPrereq's for: T1003-3 Windows Credential Editor
Attempting to satisfy prereq: Windows Credential Editor must exist on disk at specified location (C:\AtomicRedTeam\atomics\T1003\bin\wce.exe)
Exception calling "OpenRead" with "1" argument(s): "The underlying connection was closed: An
unexpected error occurred on a send."
At line:6 char:9
+         (New-Object System.Net.WebClient).OpenRead($url).copyto($ms)
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException

File hash mismatch, expected: 8F4EFA0DDE5320694DD1AA15542FE44FDE4899ED7B3A272063902E773B6C4933, actual: E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855
Failed to meet prereq: Windows Credential Editor must exist on disk at specified location (C:\AtomicRedTeam\atomics\T1003\bin\wce.exe)
```
The error appears to be caused by a wrong hash but actually if we look closely it's due to "The underlying connection was closed: An unexpected error occurred on a send." which happens when TLS negotiation fails.

Many online examples set TLS 1.2 explicitly but that prevents future evolution so I used [this StackOverflow answer](https://stackoverflow.com/questions/28286086/default-securityprotocol-in-net-4-5#comment89097588_36454717) to just add 1.1 and 1.2 and it works fine now!