### PR TITLE
Invoke-AtomicTest -GetPrereqs: always check for elevation status

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -213,6 +213,9 @@ function Invoke-AtomicTest {
                     }
                     elseif ($GetPrereqs) {
                         Write-KeyValue "GetPrereq's for: " $testId
+                        if ( $test.executor.elevation_required -and -not $isElevated) {
+                            Write-Host -ForegroundColor Red "Elevation required but not provided"
+                        }
                         if ($nul -eq $test.dependencies) { Write-KeyValue "No Preqs Defined"; continue }
                         foreach ($dep in $test.dependencies) {
                             $executor = Get-PrereqExecutor $test
@@ -236,9 +239,6 @@ function Invoke-AtomicTest {
                                     Write-Host -ForegroundColor Red "Failed to meet prereq: $description"
                                 }
                             }
-                        }
-                        if ( $test.executor.elevation_required -and -not $isElevated) {
-                            Write-Host -ForegroundColor Red "Elevation required but not provided"
                         }
                     }
                     elseif ($Cleanup) {


### PR DESCRIPTION
`Invoke-AtomicTest -GetPrereqs` will warn you if elevation is required but not provided (see last line):
```powershell
user> Invoke-AtomicTest T1003 -TestNumbers 5 -GetPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

GetPrereq's for: T1003-5 Dump LSASS.exe Memory using ProcDump
Attempting to satisfy prereq: ProcDump tool from Sysinternals must exist on disk at specified location (C:\AtomicRedTeam\atomics\T1003\bin\procdump.exe)
Prereq already met: ProcDump tool from Sysinternals must exist on disk at specified location (C:\AtomicRedTeam\atomics\T1003\bin\procdump.exe)
Elevation required but not provided
```
However it fails to do so for other tests that also require it:
```powershell
user> Invoke-AtomicTest T1003 -TestNumbers 4 -GetPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

GetPrereq's for: T1003-4 Registry dump of SAM, creds, and secrets
No Preqs Defined
```

The reason is that this last test doesn't have any prerequisites so the `-GetPrereqs` function returns immediately, whereas the check for elevation status is at its end.
Therefore, I suggest moving the elevation check at the beginning of `-GetPrereqs` code to ensure we always have the warning.

Here is the result with the patch:
```powershell
PS C:\Users\user> Invoke-AtomicTest T1003 -TestNumbers 4 -GetPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

GetPrereq's for: T1003-4 Registry dump of SAM, creds, and secrets
Elevation required but not provided
No Preqs Defined
PS C:\Users\user> Invoke-AtomicTest T1003 -TestNumbers 5 -GetPrereqs
PathToAtomicsFolder = C:\AtomicRedTeam\atomics

GetPrereq's for: T1003-5 Dump LSASS.exe Memory using ProcDump
Elevation required but not provided
Attempting to satisfy prereq: ProcDump tool from Sysinternals must exist on disk at specified location (C:\AtomicRedTeam\atomics\T1003\bin\procdump.exe)
Prereq already met: ProcDump tool from Sysinternals must exist on disk at specified location (C:\AtomicRedTeam\atomics\T1003\bin\procdump.exe)
```