### PR TITLE
Escape quote issue fixed

### DIFF
--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -4,15 +4,16 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
         $finalCommand = $finalCommand.trim()
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
-            $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
             $execPrefix = "-c"
             $execExe = $executor
             if ($executor -eq "command_prompt") { 
                     $execPrefix = "/c"; 
                     $execExe = "cmd.exe"; 
+		    $finalCommand = $finalCommand -replace "[\\`"]", "`^$&"
                     $execCommand = $finalCommand -replace "`n", " & " 
             }
             else {
+                    $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
                     $execCommand = $finalCommand -replace "(?<!;)\n", "; "
             }
             $arguments = "$execPrefix `"$execCommand`""

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -9,7 +9,6 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             if ($executor -eq "command_prompt") { 
                     $execPrefix = "/c"; 
                     $execExe = "cmd.exe"; 
-		    $finalCommand = $finalCommand -replace "[\\`"]", "`^$&"
                     $execCommand = $finalCommand -replace "`n", " & " 
             }
             else {

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -4,6 +4,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
         $finalCommand = $finalCommand.trim()
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
+            $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
             $execCommand = $finalCommand.Replace("`n", " & ")
             $execPrefix = "-c"
             $execExe = $executor

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -5,10 +5,16 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
             $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
-            $execCommand = $finalCommand -replace "(?<!;)\n", "; "
             $execPrefix = "-c"
             $execExe = $executor
-            if ($executor -eq "command_prompt") { $execPrefix = "/c"; $execExe = "cmd.exe" }
+            if ($executor -eq "command_prompt") { 
+                    $execPrefix = "/c"; 
+                    $execExe = "cmd.exe"; 
+                    $execCommand = $finalCommand -replace "`n", " & " 
+            }
+            else {
+                    $execCommand = $finalCommand -replace "(?<!;)\n", "; "
+            }
             $arguments = "$execPrefix `"$execCommand`""
         }
         elseif ($executor -eq "powershell") {

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -18,7 +18,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $arguments = "$execPrefix `"$execCommand`""
         }
         elseif ($executor -eq "powershell") {
-            $execCommand = $finalCommand -replace "[```"]", "`\$&"
+            $execCommand = $finalCommand -replace "`"", "`\`"`""
             if ($session) {
                 if ($targetPlatform -eq "windows") {
                         $execExe = "powershell.exe"

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -12,7 +12,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $arguments = "$execPrefix `"$execCommand`""
         }
         elseif ($executor -eq "powershell") {
-            $execCommand = $finalCommand -replace "`"", "`\`"`""
+            $execCommand = $finalCommand -replace "[```"]", "`\$&"
             if ($session) {
                 if ($targetPlatform -eq "windows") {
                         $execExe = "powershell.exe"

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -5,7 +5,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
             $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
-            $execCommand = $finalCommand.Replace("`n", " & ")
+            $execCommand = $finalCommand -replace "(?<!;)`n", " & "
             $execPrefix = "-c"
             $execExe = $executor
             if ($executor -eq "command_prompt") { $execPrefix = "/c"; $execExe = "cmd.exe" }

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -5,7 +5,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
             $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
-            $execCommand = $finalCommand -replace "(?<!;)`n", " & "
+            $execCommand = $finalCommand -replace "(?<!;)\n", "; "
             $execPrefix = "-c"
             $execExe = $executor
             if ($executor -eq "command_prompt") { $execPrefix = "/c"; $execExe = "cmd.exe" }


### PR DESCRIPTION
**Issues**
1. Escape characters within double quotes are not escaped properly. See Issue #23 . 
2. New lines are replaced with & which causes some of the tests to break. (No issue created.)

**Fixes**
1. Escaped the escaping characters using regex. 
2. New lines which are not ended with semicolon are replaced with semicolon ;. 

**Tests**
Tested a handful of Windows, Linux and Mac tests. 