### PR TITLE
Missing Tech .yaml swap continue for return

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -133,7 +133,7 @@ function Invoke-AtomicTest {
             if (Test-Path -Path $pathToYaml) { $AtomicTechniqueHash = Get-AtomicTechnique -Path $pathToYaml }
             else {
                 Write-Host -Fore Red "ERROR: $PathToYaml does not exist`nCheck your Atomic Number and your PathToAtomicsFolder parameter"
-                continue
+                return
             }
             $techniqueCount = 0
 


### PR DESCRIPTION
Running Invoke-AtomicTest exits the program when a technique yaml file is not found. Since we're not in a loop, a return statement will hand control back to the calling program.