### PR TITLE
Increase Atomic GUI Session Timeout

### DIFF
--- a/Public/Start-AtomicGUI.ps1
+++ b/Public/Start-AtomicGUI.ps1
@@ -222,7 +222,8 @@ function Start-AtomicGUI {
     ############## End Static Definitions
 
     ############## The Dashboard
-    $db = New-UDDashboard -Title "Atomic Test Creation" -IdleTimeout 10080 -EndpointInitialization $ei -Content {
+    $idleTimeOut = New-TimeSpan -Minutes 10080
+    $db = New-UDDashboard -Title "Atomic Test Creation" -IdleTimeout $idleTimeOut -EndpointInitialization $ei -Content {
         New-UDCard -Id "mainCard" -Content {
             New-UDCard -Content {
                 New-UDTextBoxX 'atomicName' "Atomic Test Name"

--- a/Public/Start-AtomicGUI.ps1
+++ b/Public/Start-AtomicGUI.ps1
@@ -222,7 +222,7 @@ function Start-AtomicGUI {
     ############## End Static Definitions
 
     ############## The Dashboard
-    $db = New-UDDashboard -Title "Atomic Test Creation" -EndpointInitialization $ei -Content {
+    $db = New-UDDashboard -Title "Atomic Test Creation" -IdleTimeout 10080 -EndpointInitialization $ei -Content {
         New-UDCard -Id "mainCard" -Content {
             New-UDCard -Content {
                 New-UDTextBoxX 'atomicName' "Atomic Test Name"


### PR DESCRIPTION
The Atomic GUI session goes stale by default at 25 minutes. This change allows it to remain active and usable for 7 days.