### PR TITLE
Issue#40 stdout/stderr should be returned to the caller.

### DIFF
--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -1,4 +1,4 @@
-function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $session = $null) {
+function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $session = $null, $interactive) {
     $null = @(
         if ($null -eq $finalCommand) { return 0 }
         $finalCommand = $finalCommand.trim()
@@ -39,9 +39,17 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile "art-out.txt" -stderrFile "art-err.txt"  }
         }
         else {
-            $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds -stdoutFile "art-out.txt" -stderrFile "art-err.txt" 
+            if ($interactive) {
+                # This use case is: Local execution of tests that contain interactive prompts
+                #   In this situation, let the stdout/stderr flow to the console
+                $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds
+            }
+            else {
+                # Local execution that DO NOT contain interactive prompts
+                #   In this situation, capture the stdout/stderr for Invoke-AtomicTest to send to the caller
+                $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds -stdoutFile "art-out.txt" -stderrFile "art-err.txt" 
+            }
         }
-
     )
     $res
 }

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -39,7 +39,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $TimeoutSeconds, $sess
             $res = invoke-command -Session $session -ScriptBlock { Invoke-Process -filename $Using:execExe -Arguments $Using:arguments -TimeoutSeconds $Using:TimeoutSeconds -stdoutFile "art-out.txt" -stderrFile "art-err.txt"  }
         }
         else {
-            $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds
+            $res = Invoke-Process -filename $execExe -Arguments $arguments -TimeoutSeconds $TimeoutSeconds -stdoutFile "art-out.txt" -stderrFile "art-err.txt" 
         }
 
     )

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -230,14 +230,14 @@ function Invoke-AtomicTest {
                             $final_command_prereq = Merge-InputArgs $dep.prereq_command $test $InputArgs $PathToPayloads
                             if ($executor -ne "powershell") { $final_command_prereq = ($final_command_prereq.trim()).Replace("`n", " && ") }
                             $final_command_get_prereq = Merge-InputArgs $dep.get_prereq_command $test $InputArgs $PathToPayloads
-                            $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds $session
+                            $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds $session -Interactive:$Interactive
 
                             if ($res -eq 0) {
                                 Write-KeyValue "Prereq already met: " $description
                             }
                             else {
-                                $res = Invoke-ExecuteCommand $final_command_get_prereq $executor $TimeoutSeconds $session
-                                $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds $session
+                                $res = Invoke-ExecuteCommand $final_command_get_prereq $executor $TimeoutSeconds $session -Interactive:$Interactive
+                                $res = Invoke-ExecuteCommand $final_command_prereq $executor $TimeoutSeconds $session -Interactive:$Interactive
                                 if ($res -eq 0) {
                                     Write-KeyValue "Prereq successfully met: " $description
                                 }
@@ -250,14 +250,14 @@ function Invoke-AtomicTest {
                     elseif ($Cleanup) {
                         Write-KeyValue "Executing cleanup for test: " $testId
                         $final_command = Merge-InputArgs $test.executor.cleanup_command $test $InputArgs $PathToPayloads
-                        $res = Invoke-ExecuteCommand $final_command $test.executor.name $TimeoutSeconds $session
+                        $res = Invoke-ExecuteCommand $final_command $test.executor.name $TimeoutSeconds $session -Interactive:$Interactive
                         Write-KeyValue "Done executing cleanup for test: " $testId
                     }
                     else {
                         Write-KeyValue "Executing test: " $testId
                         $startTime = get-date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
-                        $res = Invoke-ExecuteCommand $final_command $test.executor.name $TimeoutSeconds $session $Interactive
+                        $res = Invoke-ExecuteCommand $final_command $test.executor.name $TimeoutSeconds $session -Interactive:$Interactive
                         if ($session) {
                             write-output (Invoke-Command -Session $session -scriptblock { Get-Content $($Using:tmpDir + "art-out.txt"); Get-Content $($Using:tmpDir + "art-err.txt"); Remove-Item $($Using:tmpDir + "art-out.txt"), $($Using:tmpDir + "art-err.txt") -Force -ErrorAction Ignore })
                         }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -253,6 +253,20 @@ function Invoke-AtomicTest {
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name  $TimeoutSeconds $session
                         if ($session) { write-output (Invoke-Command -Session $session -scriptblock { Get-Content $($Using:tmpDir + "art-out.txt"); Get-Content $($Using:tmpDir + "art-err.txt"); Remove-Item $($Using:tmpDir + "art-out.txt"), $($Using:tmpDir + "art-err.txt") -Force -ErrorAction Ignore })}
+                        # It is possible that we have a null $session BUT we also
+                        #   have some stdout and stderr captured from the executed command.
+                        # IF there are some stdout and stderr files present then we want to 
+                        #   write this output to the pipe and then cleanup those files.
+                        $stdoutFilename = $tmpDir + "art-out.txt"
+                        if (Test-Path $stdoutFilename -PathType leaf) { 
+                            Write-Output (Get-Content $stdoutFilename)
+                            Remove-Item $stdoutFilename
+                        }
+                        $stderrFilename = $tmpDir + "art-err.txt"
+                        if (Test-Path $stderrFilename -PathType leaf) { 
+                            Write-Output (Get-Content $stderrFilename)
+                            Remove-Item $stderrFilename
+                        }
                         Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $targetHostname $targetUser $test.auto_generated_guid
                         Write-KeyValue "Done executing test: " $testId
                     }


### PR DESCRIPTION
This fix is meant to fix Issue #40 related to the stdout/stderr not being returned to the caller of Invoke-AtomicTest. With this fix, the call can be made and the output can be redirected into a log file for posterity 8-D

**NOTE:** this fix adds a command line option to the Invoke-AtomicTest called **"-Interactive"** that will allow the caller to interact with the test command (instead of all of the stdout/stderr flowing to a file without the caller seeing it).
This fix has been tested but not code reviewed. Please weigh in on this. I've got an environment setup to exercise this change for debugging if you have an problems. That being said, I haven't used the Invoke system to run remote test commands so I haven't done any testing with that part of the system.

There is probably some documentation that I should update for this. Can I get a pointer to where I should do that?