### PR TITLE
More flexible parameters for invoking maldocs

### DIFF
--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -39,7 +39,7 @@ function Invoke-MalDoc {
 #>
 
     Param(
-        [Parameter(Position = 0, Mandatory = $True, ParameterSetName = 'execution')]
+        [Parameter(Position = 0, Mandatory = $True)]
         [String]$macroCode,
 
         [Parameter(Position = 1, Mandatory = $True)]
@@ -49,10 +49,10 @@ function Invoke-MalDoc {
         [ValidateSet("Word", "Excel")]
         [String]$officeProduct,
 
-        [Parameter(Position = 3, Mandatory = $false, ParameterSetName = 'execution')]
+        [Parameter(Position = 3, Mandatory = $false)]
         [String]$sub = "Test",
 
-        [Parameter(Position = 4, Mandatory = $false, ParameterSetName = 'execution')]
+        [Parameter(Position = 4, Mandatory = $false)]
         [switch]$noWrap
     )
 

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -1,6 +1,3 @@
-# Maldoc Handler
-# This function uses COM objects to emulate the creation and execution of malicious office documents
-
 function Invoke-MalDoc {
     <#
     .SYNOPSIS

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -77,5 +77,5 @@ function Invoke-MalDoc {
     [System.Runtime.InteropServices.Marshal]::ReleaseComObject($app) | Out-Null
     [System.GC]::Collect()
     [System.GC]::WaitForPendingFinalizers()
-    Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
+    Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\" -Name 'AccessVBOM' -ErrorAction Ignore
 }

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -6,9 +6,9 @@ function Invoke-MalDoc {
     .DESCRIPTION
     A module to programatically execute Microsoft Word and Exel Documents containing macros. The module will add a registry key to allow PowerShell to interact with VBA. Use the `-Cleanup` flag to revert this change
     .PARAMETER macroCode
-    [Required] The VBA code to be executed. By default, this macro code will be wrapped in a sub routine, called "Test" by default. If you don't want your macro code to be wrapped in a sub routine use the `-noWrap` flag. To specify the subroutine name use the `-sub` parameter.
+    [Required] The VBA code to be executed. By default, this macro code will be wrapped in a sub routine, called "Test" by default. If you don't want your macro code to be wrapped in a subroutine use the `-noWrap` flag. To specify the subroutine name use the `-sub` parameter.
     .PARAMETER officeVersion
-    [Required] The Microsoft Office version to use for executing the document. E.g. "16.0"
+    [Required] The Microsoft Office version to use for executing the document. e.g. "16.0"
     .PARAMETER officeProduct
     [Required] The Microsoft Office application in which to create and execute the macro, either "Word" or "Excel".
     .PARAMETER sub
@@ -20,6 +20,12 @@ function Invoke-MalDoc {
     C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeVersion "16.0" -officeProduct "Word"
     -----------
     Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "Test" and then executed.
+    
+    .EXAMPLE
+    C:\PS> $macroCode = Get-Content path/to/macro.txt -Raw
+    C:\PS> Invoke-Maldoc -macroCode $macroCode -officeVersion "16.0" -officeProduct "Word"
+    -----------
+    Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macro code read from `path/to/macro.txt` will be wrapped inside of a subroutine call "Test" and then executed.
     
     .EXAMPLE
     C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeVersion "15.0" -officeProduct "Excel" -sub "DoIt"

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -62,13 +62,21 @@ function Invoke-MalDoc {
     } 
     $app = New-Object -ComObject "$officeProduct.Application"
     if ($officeProduct -eq "Word") {
-        $null = $app.Documents.Add()
+        $doc = $app.Documents.Add()
+        $null = $app.ActiveDocument.VBProject.VBComponents.Add(1)
     }
     else {
         $null = $app.Workbooks.Add()
+        $null = $app.VBE.ActiveVBProject.VBComponents.Add(1)
+
     }
-    $null = $app.VBE.ActiveVBProject.VBComponents.Add(1)
     $app.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macroCode)
     $app.Run($sub)
+    if ($officeProduct -eq "Word") {
+        $doc.Close(0)
+    }
+    else {
+        $app.Quit()
+    }
     Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
 }

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -1,36 +1,82 @@
 # Maldoc Handler
 # This function uses COM objects to emulate the creation and execution of malicious office documents
 
-function Invoke-MalDoc($macro_code, $office_version, $office_product) {
-    
-    $macro_code = "Sub Test()`n" + $macro_code + "`nEnd Sub"    
-    
-    if ($office_product -eq "Word") {
-        Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$office_version\Word\Security\" -Name 'AccessVBOM' -Value 1
-        
-        $word = New-Object -ComObject "Word.Application"
-        $doc = $word.Documents.Add()
-       
-        $word.ActiveDocument.VBProject.VBComponents.Add(1)
-        $word.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macro_code)
+function Invoke-MalDoc {
+    <#
+    .SYNOPSIS
+    A module to programatically execute Microsoft Word and Exel Documents containing macros.
 
-        $word.Run("Test")
-        $doc.Close(0)
-    }
-    elseif ($office_product -eq "Excel") {
-        Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$office_version\Excel\Security\" -Name 'AccessVBOM' -Value 1
-        
-        $excel = New-Object -ComObject "Excel.Application"
-        $excel.Workbooks.Add()
-        
-        $excel.VBE.ActiveVBProject.VBComponents.Add(1)
-        $excel.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macro_code)
-        
-        $excel.Run("Test")
-        $excel.DisplayAlerts = $False
-        $excel.Quit()
+    .DESCRIPTION
+    A module to programatically execute Microsoft Word and Exel Documents containing macros. The module will add a registry key to allow PowerShell to interact with VBA. Use the `-Cleanup` flag to revert this change
+    .PARAMETER macroCode
+    [Required] The VBA code to be executed. By default, this macro code will be wrapped in a sub routine, called "Test" by default. If you don't want your macro code to be wrapped in a sub routine use the `-noWrap` flag. To specify the subroutine name use the `-sub` parameter.
+    .PARAMETER officeVersion
+    [Required] The Microsoft Office version to use for executing the document. E.g. "16.0"
+    .PARAMETER officeProduct
+    [Required] The Microsoft Office application in which to create and execute the macro, either "Word" or "Excel".
+    .PARAMETER sub
+    [Optional] The name of the subroutine in the macro code to call for execution. Also the name of the subroutine to wrap the supplied `macroCode` in if `noWrap` is not specified.
+    .PARAMETER noWrap
+    [Optional] A switch that specifies that the supplied `macroCode` should be used as-is and not wrapped in a subroutine.
+    
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeVersion "16.0" -officeProduct "Word"
+    -----------
+    Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "Test" and then executed.
+    
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeVersion "15.0" -officeProduct "Excel" -sub "DoIt"
+    -----------
+    Create a macro enabled Microsoft Excel Document (using the installed Office version 15.0). The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "DoIt" and then executed.
+
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -macroCode "Sub Exec()`nMsgBox `"Hello`"`nEnd Sub" -officeVersion "16.0" -officeProduct "Word" -noWrap -sub "Exec"
+    -----------
+    Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macroCode will be unmodified (i.e. not wrapped insided a subroutine) and the "Exec" subroutine will be executed.
+
+    .EXAMPLE
+    C:\PS> Invoke-Maldoc -officeVersion "16.0" -officeProduct "Word" -Cleanup
+    Remove the Office Security AccessVBOM registry key
+#>
+
+    Param(
+        [Parameter(Position = 0, Mandatory = $True, ParameterSetName = 'execution')]
+        [String]$macroCode,
+
+        [Parameter(Position = 1, Mandatory = $True)]
+        [String]$officeVersion,
+
+        [Parameter(Position = 2, Mandatory = $True)]
+        [ValidateSet("Word", "Excel")]
+        [String]$officeProduct,
+
+        [Parameter(Position = 3, Mandatory = $false, ParameterSetName = 'execution')]
+        [String]$sub = "Test",
+
+        [Parameter(Position = 4, Mandatory = $false, ParameterSetName = 'execution')]
+        [switch]$noWrap,
+
+        [Parameter(Mandatory = $True, ParameterSetName = 'cleanup')]
+        [switch]$Cleanup
+    )
+
+    if ($Cleanup) {
+        Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
     }
     else {
-        Write-Host -ForegroundColor Red "$office_product not supported"
+        if (-not $noWrap) {
+            $macroCode = "Sub $sub()`n" + $macroCode + "`nEnd Sub"
+        } 
+        Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\" -Name 'AccessVBOM' -Value 1
+        $app = New-Object -ComObject "$officeProduct.Application"
+        if ($officeProduct -eq "Word") {
+            $null = $app.Documents.Add()
+        }
+        else {
+            $null = $app.Workbooks.Add()
+        }
+        $null = $app.VBE.ActiveVBProject.VBComponents.Add(1)
+        $app.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macroCode)
+        $app.Run($sub)
     }
 }

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -66,17 +66,14 @@ function Invoke-MalDoc {
         $null = $app.ActiveDocument.VBProject.VBComponents.Add(1)
     }
     else {
-        $null = $app.Workbooks.Add()
+        $doc = $app.Workbooks.Add()
         $null = $app.VBE.ActiveVBProject.VBComponents.Add(1)
 
     }
     $app.VBE.ActiveVBProject.VBComponents.Item("Module1").CodeModule.AddFromString($macroCode)
     $app.Run($sub)
-    if ($officeProduct -eq "Word") {
-        $doc.Close(0)
-    }
-    else {
-        $app.Quit()
-    }
+    $doc.Close(0)
+    $app.Quit()
+
     Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\' -Name 'AccessVBOM' -ErrorAction Ignore
 }


### PR DESCRIPTION
Using named parameters. New `-noWrap` flag lets you specify that you don't want your macro code put inside a subroutine. New `-sub` parameter lets you specify the name of the subroutine to call. Registry key property for AccessVBOM removed by default at end of invoke. Full help documentation and examples added. This supersedes PR #45  

This is backwards compatible. Current atomics do not need to be updated.