### PR TITLE
Invoke-Maldoc: determine version automatically

### DIFF
--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -8,7 +8,7 @@ function Invoke-MalDoc {
     .PARAMETER macroCode
     [Required] The VBA code to be executed. By default, this macro code will be wrapped in a sub routine, called "Test" by default. If you don't want your macro code to be wrapped in a subroutine use the `-noWrap` flag. To specify the subroutine name use the `-sub` parameter.
     .PARAMETER officeVersion
-    [Required] The Microsoft Office version to use for executing the document. e.g. "16.0"
+    [Optional] The Microsoft Office version to use for executing the document. e.g. "16.0". The version will be determined Programmatically if not specified.
     .PARAMETER officeProduct
     [Required] The Microsoft Office application in which to create and execute the macro, either "Word" or "Excel".
     .PARAMETER sub
@@ -17,32 +17,32 @@ function Invoke-MalDoc {
     [Optional] A switch that specifies that the supplied `macroCode` should be used as-is and not wrapped in a subroutine.
     
     .EXAMPLE
-    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeVersion "16.0" -officeProduct "Word"
+    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeProduct "Word"
     -----------
-    Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "Test" and then executed.
+    Create a macro enabled Microsoft Word Document. The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "Test" and then executed.
     
     .EXAMPLE
     C:\PS> $macroCode = Get-Content path/to/macro.txt -Raw
-    C:\PS> Invoke-Maldoc -macroCode $macroCode -officeVersion "16.0" -officeProduct "Word"
+    C:\PS> Invoke-Maldoc -macroCode $macroCode -officeProduct "Word"
     -----------
-    Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macro code read from `path/to/macro.txt` will be wrapped inside of a subroutine call "Test" and then executed.
+    Create a macro enabled Microsoft Word Document. The macro code read from `path/to/macro.txt` will be wrapped inside of a subroutine call "Test" and then executed.
     
     .EXAMPLE
-    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeVersion "15.0" -officeProduct "Excel" -sub "DoIt"
+    C:\PS> Invoke-Maldoc -macroCode "MsgBox `"Hello`"" -officeProduct "Excel" -sub "DoIt"
     -----------
-    Create a macro enabled Microsoft Excel Document (using the installed Office version 15.0). The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "DoIt" and then executed.
+    Create a macro enabled Microsoft Excel Document. The macro code `MsgBox "Hello"` will be wrapped inside of a subroutine call "DoIt" and then executed.
 
     .EXAMPLE
-    C:\PS> Invoke-Maldoc -macroCode "Sub Exec()`nMsgBox `"Hello`"`nEnd Sub" -officeVersion "16.0" -officeProduct "Word" -noWrap -sub "Exec"
+    C:\PS> Invoke-Maldoc -macroCode "Sub Exec()`nMsgBox `"Hello`"`nEnd Sub" -officeProduct "Word" -noWrap -sub "Exec"
     -----------
-    Create a macro enabled Microsoft Word Document (using the installed Office version 16.0). The macroCode will be unmodified (i.e. not wrapped insided a subroutine) and the "Exec" subroutine will be executed.
+    Create a macro enabled Microsoft Word Document. The macroCode will be unmodified (i.e. not wrapped insided a subroutine) and the "Exec" subroutine will be executed.
 #>
 
     Param(
         [Parameter(Position = 0, Mandatory = $True)]
         [String]$macroCode,
 
-        [Parameter(Position = 1, Mandatory = $True)]
+        [Parameter(Position = 1, Mandatory = $False)]
         [String]$officeVersion,
 
         [Parameter(Position = 2, Mandatory = $True)]
@@ -56,11 +56,12 @@ function Invoke-MalDoc {
         [switch]$noWrap
     )
 
+    $app = New-Object -ComObject "$officeProduct.Application"
+    if(-not $officeVersion) { $officeVersion = $app.Version } 
     Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\" -Name 'AccessVBOM' -Value 1
     if (-not $noWrap) {
         $macroCode = "Sub $sub()`n" + $macroCode + "`nEnd Sub"
     } 
-    $app = New-Object -ComObject "$officeProduct.Application"
     if ($officeProduct -eq "Word") {
         $doc = $app.Documents.Add()
     }

--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -58,7 +58,9 @@ function Invoke-MalDoc {
 
     $app = New-Object -ComObject "$officeProduct.Application"
     if(-not $officeVersion) { $officeVersion = $app.Version } 
-    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\" -Name 'AccessVBOM' -Value 1
+    $Key = "HKCU:\Software\Microsoft\Office\$officeVersion\$officeProduct\Security\"
+	if(-not (Test-Path $key)) { New-Item $Key }
+    Set-ItemProperty -Path $Key -Name 'AccessVBOM' -Value 1
     if (-not $noWrap) {
         $macroCode = "Sub $sub()`n" + $macroCode + "`nEnd Sub"
     } 


### PR DESCRIPTION
Passing office version was required previously but is now option as Invoke-Maldoc will determine it programmatically if not specified. New code also created needed registry key if it doesn't exist (for example if Word hasn't been run before)