### PR TITLE
fix backwards compatibility

### DIFF
--- a/Public/Invoke-MalDoc.ps1
+++ b/Public/Invoke-MalDoc.ps1
@@ -50,7 +50,7 @@ function Invoke-MalDoc {
         [Parameter(Position = 0, Mandatory = $True, ParameterSetName = "code")]
         [String]$macroCode,
 
-        [Parameter(Position = 0, Mandatory = $True, ParameterSetName = "file")]
+        [Parameter(Position = 5, Mandatory = $True, ParameterSetName = "file")]
         [String]$macroFile,
 
         [Parameter(Position = 1, Mandatory = $False)]


### PR DESCRIPTION
needed to change parameter position so that existing atomics can still be called the old way using positional parameters