### PR TITLE
include only T# directories when searching for atomic yaml files

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -285,9 +285,9 @@ function Invoke-AtomicTest {
         if ($AtomicTechnique -eq "All") {
             function Invoke-AllTests() {
                 $AllAtomicTests = New-Object System.Collections.ArrayList
-                Get-ChildItem $PathToAtomicsFolder -Recurse -Filter *.yaml -File | ForEach-Object {
-                    $currentTechnique = [System.IO.Path]::GetFileNameWithoutExtension($_.FullName)
-                    if ( $currentTechnique -ne "index" ) { $AllAtomicTests.Add($currentTechnique) | Out-Null }
+                Get-ChildItem $PathToAtomicsFolder -Directory -Filter T* | ForEach-Object {
+                    $currentTechnique = [System.IO.Path]::GetFileName($_.FullName)
+                    if ( $currentTechnique -match "T[0-9]{4}.?([0-9]{3})?" ) { $AllAtomicTests.Add($currentTechnique) | Out-Null }
                 }
                 $AllAtomicTests.GetEnumerator() | Foreach-Object { Invoke-AtomicTestSingle $_ }
             }


### PR DESCRIPTION
The code was recursively looking for yaml files to find T# files but it was erroneously also include other yaml files find within the /bin and /src directories, resulting in errors like the one shown below.

The new code only looks for directories in the atomics folder that match the T# format.

`ERROR: C:\AtomicRedTeam\atomics\CRONJOB\CRONJOB.yaml does not exist
Check your Atomic Number and your PathToAtomicsFolder parameter`