### PR TITLE
Add tab completion support for atomic techniques

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -351,7 +351,10 @@ function Get-DynamicFlowParamAtomics()
         $PathToAtomicsFolder = $( if ($IsLinux -or $IsMacOS) { $Env:HOME + "/AtomicRedTeam/atomics" } else { $env:HOMEDRIVE + "\AtomicRedTeam\atomics" })
     }
 
-    New-DynamicParam -Name AtomicTechnique -ValueFromPipelineByPropertyName -Mandatory -ParameterSetName 'technique' -Position 0 -type string -ValidateSet $(((gci $PathToAtomicsFolder\T*\* -Filter *.yaml).name) -replace "\.yaml","") -DPDictionary $Dictionary
+    $ValidateSetAtomics = @("All")
+    $ValidateSetAtomics += $(((gci $PathToAtomicsFolder\T*\* -Filter *.yaml).name) -replace "\.yaml","")
+
+    New-DynamicParam -Name AtomicTechnique -ValueFromPipelineByPropertyName -Mandatory -ParameterSetName 'technique' -Position 0 -type string -ValidateSet $ValidateSetAtomics -DPDictionary $Dictionary
 
     $Dictionary
 }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -344,8 +344,13 @@ function Get-DynamicFlowParamAtomics()
         $Params
     )
     $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+    
+    if ($Params.containskey('PathToAtomicsFolder')) {
+        $PathToAtomicsFolder = (Resolve-Path $Params['PathToAtomicsFolder']).Path
+    } else {
+        $PathToAtomicsFolder = $( if ($IsLinux -or $IsMacOS) { $Env:HOME + "/AtomicRedTeam/atomics" } else { $env:HOMEDRIVE + "\AtomicRedTeam\atomics" })
+    }
 
-    $PathToAtomicsFolder = (Resolve-Path $Params['PathToAtomicsFolder']).Path
     New-DynamicParam -Name AtomicTechnique -ValueFromPipelineByPropertyName -Mandatory -ParameterSetName 'technique' -Position 0 -type string -ValidateSet $(((gci $PathToAtomicsFolder\T*\* -Filter *.yaml).name) -replace "\.yaml","") -DPDictionary $Dictionary
 
     $Dictionary


### PR DESCRIPTION
Improve usability by adding dynamic parameter support for atomic techniques. This allows **tab completion support for the available techniques**. Further improvement could be to use the display name of the technique instead of the ID and translate that later to the technique ID in the code.

The important part is the following - getting all the filenames from the path (either default or given by the user) and remove the extension.
```
-ValidateSet $(((gci $PathToAtomicsFolder\T*\* -Filter *.yaml).name) -replace "\.yaml","")
```

I don't use the framework much, so I'm thankful if someone could test if anything breaks due to the change. Parameter settings like pipeline support or the position are still ensured.

Use `<tab>` to jump through the techniques or use `<ctrl-space>` to list them.

``` powershell
# use a prefix and then tab complete to get all the available techniques and browse through them
PS> Invoke-AtomicTest -PathToAtomicsFolder .\atomic-red-team\atomics\ -AtomicTechnique T10<ctrl-space>
T1003      T1006      T1021.001  T1030      T1037.002  T1049      T1055      T1059.001  T1070      T1071.004  T1087.002
T1003.001  T1007      T1021.002  T1033      T1037.004  T1053.001  T1055.001  T1059.002  T1070.001  T1072      T1090.001
T1003.002  T1010      T1021.003  T1036      T1037.005  T1053.002  T1055.004  T1059.003  T1070.002  T1074.001  T1095
T1003.003  T1012      T1021.006  T1036.003  T1040      T1053.003  T1055.012  T1059.004  T1070.003  T1078.001  T1098
T1003.004  T1014      T1027      T1036.004  T1046      T1053.004  T1056.001  T1059.005  T1070.004  T1078.003  T1098.001
T1003.006  T1016      T1027.001  T1036.005  T1047      T1053.005  T1056.002  T1059.006  T1070.005  T1082      T1098.004
T1003.007  T1018      T1027.002  T1036.006  T1048      T1053.006  T1056.004  T1069.001  T1070.006  T1083
T1003.008  T1020      T1027.004  T1037.001  T1048.003  T1053.007  T1057      T1069.002  T1071.001  T1087.001

PS> Invoke-AtomicTest -PathToAtomicsFolder .\atomic-red-team\atomics\ -AtomicTechnique T1003<ctrl-space>
T1003      T1003.001  T1003.002  T1003.003  T1003.004  T1003.006  T1003.007  T1003.008  T1006      T1007

# use a prefix and then tab complete to browse through the available techniques
PS> Invoke-AtomicTest -PathToAtomicsFolder .\atomic-red-team\atomics\ -AtomicTechnique T100<tab>
PS> Invoke-AtomicTest -PathToAtomicsFolder .\atomic-red-team\atomics\ -AtomicTechnique T1003<tab>
PS> Invoke-AtomicTest -PathToAtomicsFolder .\atomic-red-team\atomics\ -AtomicTechnique T1003.001<tab>
...
```
If you directly give the technique without explicitly use the parameter name, tab completion is missing but the value is still checked against the validate set

``` powershell
# test with id at position 0 without parameter name
PS> Invoke-AtomicTest T1218.010 -PathToAtomicsFolder .\atomic-red-team\atomics\ -ShowDetailsBrief
PathToAtomicsFolder = ...

T1218.010-1 Regsvr32 local COM scriptlet execution
T1218.010-2 Regsvr32 remote COM scriptlet execution
T1218.010-3 Regsvr32 local DLL execution
T1218.010-4 Regsvr32 Registering Non DLL
T1218.010-5 Regsvr32 Silent DLL Install Call DllRegisterServer

# test with wrong technique id
PS> Invoke-AtomicTest T1218.019 -PathToAtomicsFolder .\atomic-red-team\atomics\ -ShowDetailsBrief
Invoke-AtomicTest : ...The argument "T1218.019" does not belong to the ValidateSet-Attribut "T1003;T1003.001;T1003.002;T1003.003;T1003.004;T1003.006;T1003.007;T1003.008;T
1006;T1007;T1010;T1012;T1014;T1016;T1018;T1020;T1021.001;T1021.002;T1021.003;T1021.006;T1027;T1027.001;T1027.002;T1027.004;T1030;T1033;T1036;T1036.003;T1036.004;T1036.005;..."
```