### PR TITLE
Much faster download of atomics by disabling progressbar

### DIFF
--- a/install-atomicsfolder.ps1
+++ b/install-atomicsfolder.ps1
@@ -67,6 +67,7 @@ function Install-AtomicsFolder {
             $path = Join-Path $DownloadPath "$Branch.zip"
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
             write-verbose "Beginning download of atomics folder from Github"
+            $ProgressPreference = 'SilentlyContinue' # no progressbar for much faster download
             Invoke-WebRequest $url -OutFile $path
 
             write-verbose "Extracting ART to $InstallPath"


### PR DESCRIPTION
The atomics zip file is currently just 8 MB but it takes forever to download, even on fast connections.
It seems to be an issue with invoke-webrequest and its (very precise) progress bar: https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download

Disabling it makes the download instant :) and we don't need a progress bar for such a small file

And it doesn't prevent `expand-archive` just below from showing its progress