### PR TITLE
Much faster unzipping of atomics by disabling progressbar

### DIFF
--- a/install-atomicsfolder.ps1
+++ b/install-atomicsfolder.ps1
@@ -67,7 +67,11 @@ function Install-AtomicsFolder {
             $path = Join-Path $DownloadPath "$Branch.zip"
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
             write-verbose "Beginning download of atomics folder from Github"
-            $ProgressPreference = 'SilentlyContinue' # no progressbar for much faster download
+			
+			# disable progress bar for faster performances
+			$ProgressPreference_backup = $global:ProgressPreference
+            $global:ProgressPreference = "SilentlyContinue"
+			
             Invoke-WebRequest $url -OutFile $path
 
             write-verbose "Extracting ART to $InstallPath"
@@ -77,7 +81,10 @@ function Install-AtomicsFolder {
             Move-Item $atomicsFolderUnzipped $InstallPath
             Remove-Item $zipDest -Recurse -Force
             Remove-Item $path
-
+			
+			
+			# restore progress bar preferences
+			$global:ProgressPreference = $ProgressPreference_backup
         }
         else {
             Write-Host -ForegroundColor Yellow "An atomics folder already exists at $InstallPathwAtomics. No changes were made."


### PR DESCRIPTION
Same as e4ec84253966b61ad8f47f05b5dad056090951e2 / #74  but applies to unzipping too. I don't think we need a progress for an action lasting just a couple of seconds

We have to use $global to disable the progress bar in expand-archive as described in https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/77#issuecomment-601947496

Tests with Measure-Commands show that Install-AtomicsFolder goes from 21s to just 3s 👌

Thx @clr2of8 for asking!