### PR TITLE
fix outfile file lock error

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -301,14 +301,14 @@ function Invoke-AtomicTest {
                         if (Test-Path $stdoutFilename -PathType leaf) { 
                             Write-Output ((Get-Content $stdoutFilename) -replace '\x00', '')
                             if (-not $KeepStdOutStdErrFiles) {
-                                Remove-Item $stdoutFilename
+                                try {Remove-Item $stdoutFilename -ErrorAction Stop} catch {}
                             }
                         }
                         $stderrFilename = $tmpDir + "art-err.txt"
                         if (Test-Path $stderrFilename -PathType leaf) { 
                             Write-Output ((Get-Content $stderrFilename) -replace '\x00', '')
                             if (-not $KeepStdOutStdErrFiles) { 
-                                Remove-Item $stderrFilename
+                                try {Remove-Item $stderrFilename -ErrorAction Stop} catch {}
                             }
                         }
                     }


### PR DESCRIPTION
This fixes an annoying error you get when you are invoking tests from multiple powershell windows:

![image](https://user-images.githubusercontent.com/22311332/150574569-a9b333bc-94af-4a8b-9316-f01f5abb186c.png)
