### PR TITLE
Added support for modular loggers and changes to process creation.

### DIFF
--- a/Private/Invoke-CheckPrereqs.ps1
+++ b/Private/Invoke-CheckPrereqs.ps1
@@ -9,7 +9,7 @@ function Invoke-CheckPrereqs ($test, $isElevated, $executionPlatform, $customInp
         if($executor -ne "powershell") { $final_command = ($final_Command.trim()).Replace("`n", " && ") }
         $res = Invoke-ExecuteCommand $final_command $executor $executionPlatform $TimeoutSeconds  $session
         $description = Merge-InputArgs $dep.description $test $customInputArgs $PathToAtomicsFolder
-        if ($res -ne 0) {
+        if ($res.ExitCode -ne 0) {
             $FailureReasons.add($description) | Out-Null
         }
     }

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -34,8 +34,12 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $T
         }
         else {
             Write-Warning -Message "Unable to generate or execute the command line properly. Unknown executor"
-            $res = -1
-            return $res
+            return [PSCustomObject]@{
+                    StandardOutput = ""
+                    ErrorOutput = ""
+                    ExitCode = -1
+                    IsTimeOut = $false
+                }
         }
         if ($session) {
             $scriptParentPath = Split-Path $import -Parent

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -25,42 +25,171 @@ function Invoke-Process {
         try {
             # new Process
             if ($stdoutFile) {
-                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput (Join-Path $WorkingDirectory $stdoutFile) -RedirectStandardError (Join-Path $WorkingDirectory $stderrFile)
-             }
-            else {
-                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru
-            }
-            $handle = $process.Handle # cache process.Handle, otherwise ExitCode is null from powershell processes
-
-            # wait for complete
-            $Timeout = [System.TimeSpan]::FromSeconds(($TimeoutSeconds))
-            if (-not $process.WaitForExit($Timeout.TotalMilliseconds)) {
-                Invoke-KillProcessTree $process.id
-
-                Write-Host -ForegroundColor Red "Process Timed out after $TimeoutSeconds seconds, use '-TimeoutSeconds' to specify a different timeout"
-                if ($stdoutFile) {
-                    # Add a warning in stdoutFile in case of timeout
-                    # problem: $stdoutFile was locked in writing by the process we just killed, sometimes it's too fast and the lock isn't released immediately
-                    # solution: retry at most 10 times with 100ms between each attempt
-                    For($i=0;$i -lt 10;$i++) { 
-                        try {
-                            "<timeout>" | Out-File (Join-Path $WorkingDirectory $stdoutFile) -Append -Encoding ASCII
-                            break # if we're here it means the file wasn't locked and Out-File worked, so we can leave the retry loop
-                        } catch {} # file is locked
-                        Start-Sleep -m 100
+                # new Process
+                $process = NewProcess -FileName $FileName -Arguments $Arguments -WorkingDirectory $WorkingDirectory
+                
+                # Event Handler for Output
+                $stdSb = New-Object -TypeName System.Text.StringBuilder
+                $errorSb = New-Object -TypeName System.Text.StringBuilder
+                $scripBlock = 
+                {
+                    $x = $Event.SourceEventArgs.Data
+                    if (-not [String]::IsNullOrEmpty($x))
+                    {
+                        [System.Console]::WriteLine($x)
+                        $Event.MessageData.AppendLine($x)
                     }
                 }
-            }
+                $stdEvent = Register-ObjectEvent -InputObject $process -EventName OutputDataReceived -Action $scripBlock -MessageData $stdSb
+                $errorEvent = Register-ObjectEvent -InputObject $process -EventName ErrorDataReceived -Action $scripBlock -MessageData $errorSb
 
-            if ($IsLinux -or $IsMacOS) {
-                Start-Sleep -Seconds 5 # On nix, the last 4 lines of stdout get overwritten upon return so pause for a bit to ensure user can view results
+                # execution
+                $process.Start() > $null
+                $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::Normal
+                $process.BeginOutputReadLine()
+                $process.BeginErrorReadLine()
+                
+                # wait for complete
+                $Timeout = [System.TimeSpan]::FromSeconds(($TimeoutSeconds))
+                $isTimeout = $false
+                if (-not $Process.WaitForExit($Timeout.TotalMilliseconds))
+                {
+                    $isTimeout = $true
+                    Write-Host -ForegroundColor Red "Process Timed out after $TimeoutSeconds seconds, use '-TimeoutSeconds' to specify a different timeout"
+                    Invoke-KillProcessTree $process.id
+                }
+                $process.WaitForExit(5000)
+                $process.CancelOutputRead()
+                $process.CancelErrorRead()
+
+                # verbose Event Result
+                $stdEvent, $errorEvent | VerboseOutput
+
+                # Unregister Event to recieve Asynchronous Event output (should be called before process.Dispose())
+                Unregister-Event -SourceIdentifier $stdEvent.Name
+                Unregister-Event -SourceIdentifier $errorEvent.Name
+
+                # verbose Event Result
+                $stdEvent, $errorEvent | VerboseOutput
+
+                # Get Process result
+                return GetCommandResult -Process $process -StandardStringBuilder $stdSb -ErrorStringBuilder $errorSb -IsTimeOut $isTimeout
+            }
+            else {
+                # This is the enitrety of the "old style" code, kept for interactive tests
+                $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru
+                # cache process.Handle, otherwise ExitCode is null from powershell processes
+                $handle = $process.Handle
+
+                # wait for complete
+                $Timeout = [System.TimeSpan]::FromSeconds(($TimeoutSeconds))
+                if (-not $process.WaitForExit($Timeout.TotalMilliseconds)) {
+                    Invoke-KillProcessTree $process.id
+
+                    Write-Host -ForegroundColor Red "Process Timed out after $TimeoutSeconds seconds, use '-TimeoutSeconds' to specify a different timeout"
+                    if ($stdoutFile) {
+                        # Add a warning in stdoutFile in case of timeout
+                        # problem: $stdoutFile was locked in writing by the process we just killed, sometimes it's too fast and the lock isn't released immediately
+                        # solution: retry at most 10 times with 100ms between each attempt
+                        For($i=0;$i -lt 10;$i++) { 
+                            try {
+                                "<timeout>" | Out-File (Join-Path $WorkingDirectory $stdoutFile) -Append -Encoding ASCII
+                                break # if we're here it means the file wasn't locked and Out-File worked, so we can leave the retry loop
+                            } catch {} # file is locked
+                            Start-Sleep -m 100
+                        }
+                    }
+                }
+
+                if ($IsLinux -or $IsMacOS) {
+                    Start-Sleep -Seconds 5 # On nix, the last 4 lines of stdout get overwritten upon return so pause for a bit to ensure user can view results
+                }
+                
+                # Get Process result
+                return [PSCustomObject]@{
+                    StandardOutput = ""
+                    ErrorOutput = ""
+                    ExitCode = $process.ExitCode
+                    IsTimeOut = $IsTimeout
+                }
+
             }
             
-            # Get Process result 
-            return $process.ExitCode
         }
         finally {
             if ($null -ne $process) { $process.Dispose() }
+            if ($null -ne $stdEvent){ $stdEvent.StopJob(); $stdEvent.Dispose() }
+            if ($null -ne $errorEvent){ $errorEvent.StopJob(); $errorEvent.Dispose() }
+        }
+    }
+
+    begin
+    {
+        function NewProcess
+        {
+            [OutputType([System.Diagnostics.Process])]
+            [CmdletBinding()]
+            param
+            (
+                [parameter(Mandatory = $true)]
+                [string]$FileName,
+                
+                [parameter(Mandatory = $false)]
+                [string]$Arguments,
+                
+                [parameter(Mandatory = $false)]
+                [string]$WorkingDirectory
+            )
+
+            "Execute command : '{0} {1}', WorkingSpace '{2}'" -f $FileName, $Arguments, $WorkingDirectory | VerboseOutput
+            # ProcessStartInfo
+            $psi = New-object System.Diagnostics.ProcessStartInfo 
+            $psi.CreateNoWindow = $true
+            $psi.UseShellExecute = $false
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.FileName = $FileName
+            $psi.Arguments+= $Arguments
+            $psi.WorkingDirectory = $WorkingDirectory
+
+            # Set Process
+            $process = New-Object System.Diagnostics.Process 
+            $process.StartInfo = $psi
+            $process.EnableRaisingEvents = $true
+            return $process
+        }
+
+        function GetCommandResult
+        {
+            [OutputType([PSCustomObject])]
+            [CmdletBinding()]
+            param
+            (
+                [parameter(Mandatory = $true)]
+                [System.Diagnostics.Process]$Process,
+
+                [parameter(Mandatory = $true)]
+                [System.Text.StringBuilder]$StandardStringBuilder,
+
+                [parameter(Mandatory = $true)]
+                [System.Text.StringBuilder]$ErrorStringBuilder,
+
+                [parameter(Mandatory = $true)]
+                [Bool]$IsTimeout
+            )
+            
+            'Get command result string.' | VerboseOutput
+            return [PSCustomObject]@{
+                StandardOutput = $StandardStringBuilder.ToString().Trim()
+                ErrorOutput = $ErrorStringBuilder.ToString().Trim()
+                ExitCode = $Process.ExitCode
+                IsTimeOut = $IsTimeout
+            }
+        }
+
+        filter VerboseOutput
+        {
+            $_ | Out-String -Stream | Write-Verbose
         }
     }
 }

--- a/Public/Default-ExecutionLogger.psm1
+++ b/Public/Default-ExecutionLogger.psm1
@@ -1,4 +1,8 @@
-function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPath, $targetHostname, $targetUser, $guid) {
+function Start-ExecutionLog($startTime, $logPath, $targetHostname, $targetUser, $commandLine, $isWindows) {
+
+}
+
+function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $stdOut, $stdErr, $isWindows) {
     if (!(Test-Path $logPath)) { 
         New-Item $logPath -Force -ItemType File | Out-Null
     } 
@@ -13,6 +17,10 @@ function Write-ExecutionLog($startTime, $technique, $testNum, $testName, $logPat
         "Test Name"              = $testName; 
         "Hostname"               = $targetHostname; 
         "Username"               = $targetUser
-        "GUID"                   = $guid
+        "GUID"                   = $testGuid
     } | Export-Csv -Path $LogPath -NoTypeInformation -Append
+}
+
+function Stop-ExecutionLog($startTime, $logPath, $targetHostname, $targetUser, $isWindows) {
+
 }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -172,6 +172,8 @@ function Invoke-AtomicTest {
             if(-not $PSBoundParameters.ContainsKey('LoggingModule')) {
                 Import-Module "$PSScriptRoot\Default-ExecutionLogger.psm1" -Force
                 $LoggingModule = "Default-ExecutionLogger"
+            } else {
+                Remove-Module -Name "Default-ExecutionLogger" -erroraction silentlycontinue
             }
         }
 

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -129,7 +129,12 @@ function Invoke-AtomicTest {
             ValueFromPipelineByPropertyName = $true,
             ParameterSetName = 'technique')]
         [switch]
-        $KeepStdOutStdErrFiles = $false
+        $KeepStdOutStdErrFiles = $false,
+
+        [Parameter(Mandatory = $false,
+            ParameterSetName = 'technique')]
+        [String]
+        $LoggingModule
 
     )
     BEGIN { } # Intentionally left blank and can be removed
@@ -141,6 +146,138 @@ function Invoke-AtomicTest {
         
         $executionPlatform, $isElevated, $tmpDir, $executionHostname, $executionUser = Get-TargetInfo $Session
         $PathToPayloads = if ($Session) { "$tmpDir`AtomicRedTeam" }  else { $PathToAtomicsFolder }
+
+        Function Get-Logger {
+            Param([string]$name)
+            if(-not(Get-Module -name $name))
+            {
+                if(Get-Module -ListAvailable |
+                    Where-Object { $_.name -eq $name })
+                {
+                    Import-Module -Name $name -Force
+                    $true
+                } #end if module available then import
+                else {
+                    $false
+                } #module not available
+            } # end if not module
+            else {
+                $true
+            } #module already loaded
+        } #end function Get-Logger
+
+        $isLoggingModuleSet = $false
+        if(-not $NoExecutionLog) {
+            $isLoggingModuleSet = $true
+            if(-not $PSBoundParameters.ContainsKey('LoggingModule')) {
+                Import-Module "$PSScriptRoot\Default-ExecutionLogger.psm1" -Force
+                $LoggingModule = "Default-ExecutionLogger"
+            }
+        }
+
+        if($isLoggingModuleSet) {
+            if(Get-Logger -name $LoggingModule) {
+                Write-Host "Using Logger: ", $LoggingModule
+            } else {
+                Write-Host "Logger not found: ", $LoggingModule
+            }
+
+            if((Get-Command Start-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
+                if((Get-Command Write-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
+                    if((Get-Command Stop-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
+                        Write-Host "All logging commands found"
+                    } else {
+                        Write-Host "Stop-ExecutionLog not found or loaded from the wrong module"
+                        return
+                    }
+                } else {
+                    Write-Host "Write-ExecutionLog not found or loaded from the wrong module"
+                    return
+                }
+            } else {
+                Write-Host "Start-ExecutionLog not found or loaded from the wrong module"
+                return
+            }
+        }
+
+        if($isLoggingModuleSet) {
+            
+            # Here we're rebuilding an equivalent command line to put in the logs
+            $commandLine = "Invoke-AtomicTest $AtomicTechnique"
+
+            if($ShowDetails -ne $false) {
+                $commandLine = "$commandLine -ShowDetails $ShowDetails"
+            }
+
+            if($ShowDetailsBrief -ne $false) {
+                $commandLine = "$commandLine -ShowDetailsBrief $ShowDetailsBrief"
+            }
+
+            if($TestNumbers -ne $null) {
+                $commandLine = "$commandLine -TestNumbers $TestNumbers"
+            }
+
+            if($TestNames -ne $null) {
+                $commandLine = "$commandLine -TestNames $TestNames"
+            }
+
+            if($TestGuids -ne $null) {
+                $commandLine = "$commandLine -TestGuids $TestGuids"
+            }
+
+            $commandLine = "$commandLine -PathToAtomicsFolder $PathToAtomicsFolder"
+
+            if($CheckPrereqs -ne $false) {
+                $commandLine = "$commandLine -CheckPrereqs $CheckPrereqs"
+            }
+
+            if($PromptForInputArgs -ne $false) {
+                $commandLine = "$commandLine -PromptForInputArgs $PromptForInputArgs"
+            }
+
+            if($GetPrereqs -ne $false) {
+                $commandLine = "$commandLine -GetPrereqs $GetPrereqs"
+            }
+
+            if($Cleanup -ne $false) {
+                $commandLine = "$commandLine -Cleanup $Cleanup"
+            }
+
+            if($NoExecutionLog -ne $false) {
+                $commandLine = "$commandLine -NoExecutionLog $NoExecutionLog"
+            }
+
+            $commandLine = "$commandLine -ExecutionLogPath $ExecutionLogPath"
+
+            if($Force -ne $false) {
+                $commandLine = "$commandLine -Force $Force"
+            }
+
+            if($InputArgs -ne $null) {
+                $commandLine = "$commandLine -InputArgs $InputArgs"
+            }
+
+            $commandLine = "$commandLine -TimeoutSeconds $TimeoutSeconds"
+
+            if($Session -ne $null) {
+                $commandLine = "$commandLine -Session $Session"
+            }
+
+            if($Interactive -ne $false) {
+                $commandLine = "$commandLine -Interactive $Interactive"
+            }
+
+            if($KeepStdOutStdErrFiles -ne $false) {
+                $commandLine = "$commandLine -KeepStdOutStdErrFiles $KeepStdOutStdErrFiles"
+            }
+
+            if($LoggingModule -ne $null) {
+                $commandLine = "$commandLine -LoggingModule $LoggingModule"
+            }
+
+            $startTime = Get-Date
+            Start-ExecutionLog $startTime $ExecutionLogPath $executionHostname $executionUser $commandLine (-Not($IsLinux -or $IsMacOS))
+        }
 
         function Platform-IncludesCloud {
             $cloud = ('office-365', 'azure-ad', 'google-workspace', 'saas', 'iaas', 'containers', 'iaas:aws', 'iaas:azure', 'iaas:gcp')
@@ -177,6 +314,7 @@ function Invoke-AtomicTest {
                 Write-Debug -Message "Gathering tests for Technique $technique"
 
                 $testCount = 0
+                $order = 1
                 foreach ($test in $technique.atomic_tests) {
 
                     Write-Verbose -Message 'Determining tests for target platform'
@@ -262,13 +400,13 @@ function Invoke-AtomicTest {
                             $final_command_get_prereq = Merge-InputArgs $dep.get_prereq_command $test $InputArgs $PathToPayloads
                             $res = Invoke-ExecuteCommand $final_command_prereq $executor $executionPlatform $TimeoutSeconds $session -Interactive:$true
 
-                            if ($res -eq 0) {
+                            if ($res.ExitCode -eq 0) {
                                 Write-KeyValue "Prereq already met: " $description
                             }
                             else {
                                 $res = Invoke-ExecuteCommand $final_command_get_prereq $executor $executionPlatform $TimeoutSeconds $session -Interactive:$Interactive
                                 $res = Invoke-ExecuteCommand $final_command_prereq $executor $executionPlatform $TimeoutSeconds $session -Interactive:$true
-                                if ($res -eq 0) {
+                                if ($res.ExitCode -eq 0) {
                                     Write-KeyValue "Prereq successfully met: " $description
                                 }
                                 else {
@@ -285,10 +423,14 @@ function Invoke-AtomicTest {
                     }
                     else {
                         Write-KeyValue "Executing test: " $testId
-                        $startTime = get-date
+                        $startTime = Get-Date
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name $executionPlatform $TimeoutSeconds $session -Interactive:$Interactive
-                        Write-ExecutionLog $startTime $AT $testCount $test.name $ExecutionLogPath $executionHostname $executionUser $test.auto_generated_guid
+                        $stopTime = Get-Date
+                        if($isLoggingModuleSet) {
+                            Write-ExecutionLog $startTime $stopTime $AT $order $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res.StandardOutput $res.ErrorOutput (-Not($IsLinux -or $IsMacOS))
+                            $order++
+                        }
                         Write-KeyValue "Done executing test: " $testId
                     }
                     if ($session) {
@@ -308,7 +450,7 @@ function Invoke-AtomicTest {
                         if (Test-Path $stderrFilename -PathType leaf) { 
                             Write-Output ((Get-Content $stderrFilename) -replace '\x00', '')
                             if (-not $KeepStdOutStdErrFiles) { 
-                                try {Remove-Item $stderrFilename -ErrorAction Stop} catch {}
+                                try {Remove-Item $stdoutFilename -ErrorAction Stop} catch {}
                             }
                         }
                     }
@@ -333,6 +475,10 @@ function Invoke-AtomicTest {
         }
         else {
             Invoke-AtomicTestSingle $AtomicTechnique
+        }
+
+        if($isLoggingModuleSet) {
+            Stop-ExecutionLog $startTime $ExecutionLogPath $executionHostname $executionUser (-Not($IsLinux -or $IsMacOS))
         }
 
     } # End of PROCESS block

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -433,27 +433,6 @@ function Invoke-AtomicTest {
                         }
                         Write-KeyValue "Done executing test: " $testId
                     }
-                    if ($session) {
-                        write-output (Invoke-Command -Session $session -scriptblock { (Get-Content $($Using:tmpDir + "art-out.txt")) -replace '\x00', ''; (Get-Content $($Using:tmpDir + "art-err.txt")) -replace '\x00', ''; if (-not $KeepStdOutStdErrFiles) { Remove-Item $($Using:tmpDir + "art-out.txt"), $($Using:tmpDir + "art-err.txt") -Force -ErrorAction Ignore } })
-                    }
-                    elseif (-not $interactive) {
-                        # It is possible to have a null $session BUT also have stdout and stderr captured from 
-                        #   the executed command. IF so then write the output to the pipe and cleanup the files.
-                        $stdoutFilename = $tmpDir + "art-out.txt"
-                        if (Test-Path $stdoutFilename -PathType leaf) { 
-                            Write-Output ((Get-Content $stdoutFilename) -replace '\x00', '')
-                            if (-not $KeepStdOutStdErrFiles) {
-                                try {Remove-Item $stdoutFilename -ErrorAction Stop} catch {}
-                            }
-                        }
-                        $stderrFilename = $tmpDir + "art-err.txt"
-                        if (Test-Path $stderrFilename -PathType leaf) { 
-                            Write-Output ((Get-Content $stderrFilename) -replace '\x00', '')
-                            if (-not $KeepStdOutStdErrFiles) { 
-                                try {Remove-Item $stdoutFilename -ErrorAction Stop} catch {}
-                            }
-                        }
-                    }
                 } # End of foreach Test in single Atomic Technique
             } # End of foreach Technique in Atomic Tests
         } # End of Invoke-AtomicTestSingle function


### PR DESCRIPTION
### Invoke-Process.ps1

There is now a new method of process creation when running in non-interactive mode. This method uses System.Diagnostics.ProcessStartInfo from the .NET API to create and retrieve output from a process. This method does not require writing files to disk to retrieve output from the process.

The previous method of using Start-Process is still used when running in interactive mode.

### Invoke-AtomicTest.ps1

There are several changes in this file to facilitate logging. There is a new input argument for the user to specify a logger and new code to load and validate the logger module.

There is a section of code to re-create an equivalent command line passed into Invoke-AtomicTest. This is needed for the ATTiRe logger, but the code needs to be in Invoke-AtomicTest to access the input arguments. The rebuilt command line may explicitly contain arguments with default values that the user did not set.

There are now 3 places where Invoke-AtomicTest passes information to the logger module through the functions Start-ExecutionLog, Write-ExecutionLog, and Stop-ExecutionLog. Start-ExecutionLog and Stop-ExecutionLog are each called once: before and after all the test cases have run, respectively. These functions are to allow the logger to perform any setup or cleanup work it may need. Write-ExecutionLog is called once after each test case and is where any of the actual logging work is performed.

### Default-ExecutionLogger.psm1

Write-ExecutionLog.ps1 has been renamed to Default-ExecutionLogger.psm1 and moved to the Public directory. The Write-ExecutionLog function remains, but with additional arguments to match the new API. These new arguments are not used by the function. Start-ExecutionLog and Stop-ExecutionLog have also been added but are empty functions. It generates the same logs as before.
