### PR TITLE
Update Invoke-ExecuteCommand.ps1

### DIFF
--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -12,7 +12,8 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $T
                     $execCommand = $finalCommand -replace "`n", " & " 
             }
             else {
-                    $finalCommand = $finalCommand -replace "[\\`"]", "`\$&"
+                    $finalCommand = $finalCommand -replace "[\\](?!;)", "`\$&"
+                    $finalCommand = $finalCommand -replace "[`"]", "`\$&"
                     $execCommand = $finalCommand -replace "(?<!;)\n", "; "
             }
             $arguments = "$execPrefix `"$execCommand`""


### PR DESCRIPTION
Issue:
The escape quote logic for bash/sh executors caused errors with `find` commands that contained an `-exec` statement.  The `\;` escape syntax for the `-exec` statement was incorrectly being escaped causing the find command to fail.  (See Issue #91)

Fix:
After reading PR #24 and PR #33, the proposed fix is to split the escape regex into two statements.  The backslash escape regex performs a negative lookahead for a semicolon (`;`).  If the semicolon is found, the backslash is not escaped.  The second regex statement looks to escape the double quote (`"`)

Testing:
Testing was performed locally on a Linux server.  Ran multiple Linux Atomic-Tests to ensure proper execution.  The tests including the following that execute an `-exec` as part of the `find` command:

- Invoke-AtomicTest T1217 -TestNumbers 1
- Invoke-AtomicTest T1552.004 -TestNumbers 3
- Invoke-AtomicTest T1552.004 -TestNumbers 4
- Invoke-AtomicTest T1552.004 -TestNumbers 5
- Invoke-AtomicTest T1083 -TestNumbers 4
