### PR TITLE
Invoke process modification

### DIFF
--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -23,7 +23,6 @@ function Invoke-Process {
     end {
         $WorkingDirectory = if ($IsLinux -or $IsMacOS) { "/tmp" } else { $env:TEMP }
         try {
-            Write-Host -ForegroundColor Cyan "Writing output to $stdOutFile"
             # new Process
             if ($stdoutFile) {
                 $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -23,8 +23,6 @@ function Invoke-Process {
     end {
         $WorkingDirectory = if ($IsLinux -or $IsMacOS) { "/tmp" } else { $env:TEMP }
         try {
-            Write-Host -ForegroundColor Cyan "Writing output to $stdOutFile"
-            # new Process
             if ($stdoutFile) {
                 $process = Start-Process -FilePath $FileName -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -NoNewWindow -PassThru -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
                 # cache process.Handle, otherwise ExitCode is null from powershell processes

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -40,9 +40,9 @@ function Invoke-Process {
                     $process.WaitForExit()
                 }
                 
-                $stdOutString = Get-Content -Path $stdoutFile -Raw
+                $stdOutString = Get-Content -Path $stdoutFile -Raw | Out-String
                 
-                $stdErrString = Get-Content -Path $stderrFile -Raw
+                $stdErrString = Get-Content -Path $stderrFile -Raw | Out-String
                 
                 if($stdOutString.Length -gt 0) {
                     Write-Host $stdOutString


### PR DESCRIPTION
Modifying Invoke-Process to use `Start-Process` with RedirectStandardOutput rather than `System.Diagnostics.Process`. This helps to solve an issue while reading standard output in WinPwn safetykatz tool. 