### PR TITLE
Add -noPayloads option to atomic install

### DIFF
--- a/install-atomicredteam.ps1
+++ b/install-atomicredteam.ps1
@@ -97,7 +97,7 @@ function Install-AtomicRedTeam {
 
             if ($getAtomics) {
                 Write-Verbose "Installing Atomics Folder"
-                Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/$RepoOwner/invoke-atomicredteam/master/install-atomicsfolder.ps1"); Install-AtomicsFolder -InstallPath $InstallPath -DownloadPath $DownloadPath -Force:$Force -RepoOwner $RepoOwner -NoPayloads:$NoPayloads
+                Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/$RepoOwner/invoke-atomicredteam/$Branch/install-atomicsfolder.ps1"); Install-AtomicsFolder -InstallPath $InstallPath -DownloadPath $DownloadPath -Force:$Force -RepoOwner $RepoOwner -NoPayloads:$NoPayloads
             }
 
             Write-Host "Installation of Invoke-AtomicRedTeam is complete. You can now use the Invoke-AtomicTest function" -Fore Yellow

--- a/install-atomicredteam.ps1
+++ b/install-atomicredteam.ps1
@@ -52,7 +52,10 @@ function Install-AtomicRedTeam {
         [switch]$getAtomics = $False,
 
         [Parameter(Mandatory = $False)]
-        [switch]$Force = $False # delete the existing install directory and reinstall
+        [switch]$Force = $False, # delete the existing install directory and reinstall
+
+        [Parameter(Mandatory = $False)]
+        [switch]$NoPayloads = $False # only download atomic yaml files during -getAtomics operation (no /src or /bin dirs)
     )
     Try {
         $InstallPathwIart = Join-Path $InstallPath "invoke-atomicredteam"
@@ -94,7 +97,7 @@ function Install-AtomicRedTeam {
 
             if ($getAtomics) {
                 Write-Verbose "Installing Atomics Folder"
-                Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/$RepoOwner/invoke-atomicredteam/master/install-atomicsfolder.ps1"); Install-AtomicsFolder -InstallPath $InstallPath -DownloadPath $DownloadPath -Force:$Force -RepoOwner $RepoOwner
+                Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/$RepoOwner/invoke-atomicredteam/master/install-atomicsfolder.ps1"); Install-AtomicsFolder -InstallPath $InstallPath -DownloadPath $DownloadPath -Force:$Force -RepoOwner $RepoOwner -NoPayloads:$NoPayloads
             }
 
             Write-Host "Installation of Invoke-AtomicRedTeam is complete. You can now use the Invoke-AtomicTest function" -Fore Yellow

--- a/install-atomicsfolder.ps1
+++ b/install-atomicsfolder.ps1
@@ -46,7 +46,10 @@ function Install-AtomicsFolder {
         [string]$Branch = "master",
 
         [Parameter(Mandatory = $False)]
-        [switch]$Force = $False # delete the existing install directory and reinstall
+        [switch]$Force = $False, # delete the existing install directory and reinstall
+
+        [Parameter(Mandatory = $False)]
+        [switch]$NoPayloads = $False
     )
     Try {
         $InstallPathwAtomics = Join-Path $InstallPath "atomics"
@@ -68,23 +71,59 @@ function Install-AtomicsFolder {
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
             write-verbose "Beginning download of atomics folder from Github"
 			
-			# disable progress bar for faster performances
-			$ProgressPreference_backup = $global:ProgressPreference
+            # disable progress bar for faster performances
+            $ProgressPreference_backup = $global:ProgressPreference
             $global:ProgressPreference = "SilentlyContinue"
 			
-            Invoke-WebRequest $url -OutFile $path
+            if ($NoPayloads) { # download zip to memory and only extract atomic yaml files
+                # load ZIP methods
+                Add-Type -AssemblyName System.IO.Compression.FileSystem
+                [System.Reflection.Assembly]::LoadWithPartialName('System.IO.Compression') | Out-Null
 
-            write-verbose "Extracting ART to $InstallPath"
-            $zipDest = Join-Path "$DownloadPath" "tmp"
-            expand-archive -LiteralPath $path -DestinationPath "$zipDest" -Force:$Force
-            $atomicsFolderUnzipped = Join-Path (Join-Path $zipDest "atomic-red-team-$Branch") "atomics"
-            Move-Item $atomicsFolderUnzipped $InstallPath
-            Remove-Item $zipDest -Recurse -Force
-            Remove-Item $path
+                # read github zip archive into memory
+                $ms = New-Object IO.MemoryStream
+                [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12)
+                (New-Object System.Net.WebClient).OpenRead($url).copyto($ms)
+                $Zip = New-Object System.IO.Compression.ZipArchive($ms)
+
+                $Filter = '*.yaml'
+
+                # ensure the output folder exists
+                $exists = Test-Path -Path $InstallPathwAtomics
+                if ($exists -eq $false) {
+                    $null = New-Item -Path $InstallPathwAtomics -ItemType Directory -Force
+                }
+
+                # find all files in ZIP that match the filter (i.e. file extension)
+                $zip.Entries | 
+                Where-Object { 
+                        ($_.FullName -like $Filter) `
+                        -and (($_.FullName | split-path | split-path -Leaf) -eq [System.IO.Path]::GetFileNameWithoutExtension($_.Name)) `
+                        -and ($_.FullName | split-path | split-path | split-path -Leaf) -eq "atomics"
+                } |
+                ForEach-Object { 
+                    # extract the selected items from the ZIP archive
+                    # and copy them to the out folder
+                    $dstDir = Join-Path $InstallPathwAtomics ($_.FullName | split-path | split-path -Leaf)
+                    New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($_, (Join-Path $dstDir $_.Name), $true)
+                }
+                $zip.Dispose()
+            }
+            else {
+                Invoke-WebRequest $url -OutFile $path
+
+                write-verbose "Extracting ART to $InstallPath"
+                $zipDest = Join-Path "$DownloadPath" "tmp"
+                expand-archive -LiteralPath $path -DestinationPath "$zipDest" -Force:$Force
+                $atomicsFolderUnzipped = Join-Path (Join-Path $zipDest "atomic-red-team-$Branch") "atomics"
+                Move-Item $atomicsFolderUnzipped $InstallPath
+                Remove-Item $zipDest -Recurse -Force
+                Remove-Item $path
+            }
 			
-			
-			# restore progress bar preferences
-			$global:ProgressPreference = $ProgressPreference_backup
+            # restore progress bar preferences
+            $global:ProgressPreference = $ProgressPreference_backup
         }
         else {
             Write-Host -ForegroundColor Yellow "An atomics folder already exists at $InstallPathwAtomics. No changes were made."


### PR DESCRIPTION
This allows the atomics folder to be downloaded/installed without downloading any of the payloads in the /src or /bin directory since these files are likely to generate many alerts. Instead, you can use the getPrereqs feature to download any payloads you need for only those tests that you are going to run.