### PR TITLE
adding new ci job to publish to gallery base on new tag to master

### DIFF
--- a/.github/workflows/publish-powershell-gallery.yml
+++ b/.github/workflows/publish-powershell-gallery.yml
@@ -1,0 +1,20 @@
+name: publish-powershell-gallery
+on:
+  push:
+    branches: [ main]
+    tags: [ 'v*.*.*' ]
+jobs:
+  publish-powershell-gallery:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        
+      - name: publishing
+        run: |
+          Publish-Module -Path '...' -NuGetApiKey ${{ secrets.PSGALLERY }}
+        shell: pwsh
+
+
+
+


### PR DESCRIPTION
should work by simply checkout out master and running/push:

`git tag v1.2.3`
`git push --tags`

will automatically update powershell gallery, uses repo secret token `PSGALLERY`, must be set. 