### PR TITLE
add syslog logging option for atomic execution

### DIFF
--- a/Invoke-AtomicRedTeam.psd1
+++ b/Invoke-AtomicRedTeam.psd1
@@ -29,7 +29,7 @@
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # AtomicClassSchema.ps1 needs to be present in the caller's scope in order for the built-in classes to surface properly.
-    ScriptsToProcess  = @('Private\AtomicClassSchema.ps1')
+    ScriptsToProcess  = @('Private\AtomicClassSchema.ps1','Public\config.ps1')
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(

--- a/Public/Default-ExecutionLogger.psm1
+++ b/Public/Default-ExecutionLogger.psm1
@@ -23,11 +23,11 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
     $msg | Export-Csv -Path $LogPath -NoTypeInformation -Append
 
     # send syslog message if a syslog server is defined in Public/config.ps1
-    if([bool]$syslogServer -and [bool]$syslogPort){
+    if([bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort){
         $UDPClient = New-Object System.Net.Sockets.UdpClient
         $msg | Add-Member -Name "Tag" -Type NoteProperty -Value "atomicrunner"
         $encodedSyslogMessage = [System.Text.Encoding]::UTF8.GetBytes(($msg | ConvertTo-Json))
-        $UDPClient.Connect($syslogServer,$syslogPort)
+        $UDPClient.Connect($artConfig.syslogServer,$artConfig.syslogPort)
         $null = $UDPClient.Send($encodedSyslogMessage, $encodedSyslogMessage.Length)
     }
 }

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -1,0 +1,2 @@
+$syslogServer = '' # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
+$syslogPort = ''

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -1,2 +1,5 @@
-$syslogServer = '' # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
-$syslogPort = ''
+
+$artConfig = [PSCustomObject]@{
+  syslogServer = ''; # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
+  syslogPort = 514;
+}


### PR DESCRIPTION
You can optionally add a syslog server and port to Public\config.ps1 and the default logger will send the atomic execution log to your syslog server as well as write it to disk. If you don't configure a syslog server, everything works the way it did before with just logging to a file.