### PR TITLE
Atomic Runner code - scripted attack emulation around the clock

### DIFF
--- a/Invoke-AtomicRedTeam.psd1
+++ b/Invoke-AtomicRedTeam.psd1
@@ -29,7 +29,7 @@
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # AtomicClassSchema.ps1 needs to be present in the caller's scope in order for the built-in classes to surface properly.
-    ScriptsToProcess  = @('Private\AtomicClassSchema.ps1')
+    ScriptsToProcess  = @('Private\AtomicClassSchema.ps1','Public\config.ps1')
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
@@ -40,7 +40,13 @@
         'New-AtomicTestInputArgument',
         'New-AtomicTestDependency',
         'Start-AtomicGUI',
-        'Stop-AtomicGUI'
+        'Stop-AtomicGUI',
+        'Invoke-SetupAtomicRunner',
+        'Invoke-GenerateNewSchedule',
+        'Invoke-RefreshExistingSchedule',
+        'Invoke-AtomicRunner',
+        'Get-Schedule',
+        'Invoke-KickoffAtomicRunner'
     )
 
     # Variables to export from this module

--- a/Invoke-AtomicRedTeam.psm1
+++ b/Invoke-AtomicRedTeam.psm1
@@ -1,5 +1,10 @@
 #requires -Version 5.0
 
+# execute amsi bypass if configured to use one
+if([bool]$artConfig.absb -and ($artConfig.OS -eq "windows")){
+    $artConfig.absb.Invoke()
+}
+
 #Get public and private function definition files.
 $Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse -ErrorAction SilentlyContinue )
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -Recurse -Exclude "AtomicClassSchema.ps1" -ErrorAction SilentlyContinue )

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -186,6 +186,7 @@ function Invoke-Process {
                 StandardOutput = $StandardStringBuilder.ToString().Trim()
                 ErrorOutput = $ErrorStringBuilder.ToString().Trim()
                 ExitCode = $Process.ExitCode
+                ProcessId = $Process.Id
                 IsTimeOut = $IsTimeout
             }
         }

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -114,6 +114,7 @@ function Invoke-Process {
                     StandardOutput = ""
                     ErrorOutput = ""
                     ExitCode = $process.ExitCode
+                    ProcessId = $Process.Id
                     IsTimeOut = $IsTimeout
                 }
 

--- a/Public/Default-ExecutionLogger.psm1
+++ b/Public/Default-ExecutionLogger.psm1
@@ -2,7 +2,7 @@ function Start-ExecutionLog($startTime, $logPath, $targetHostname, $targetUser, 
 
 }
 
-function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $stdOut, $stdErr, $isWindows) {
+function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $res, $isWindows) {
     if (!(Test-Path $logPath)) { 
         New-Item $logPath -Force -ItemType File | Out-Null
     } 
@@ -10,14 +10,16 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
     $timeUTC = (Get-Date($startTime).toUniversalTime() -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $timeLocal = (Get-Date($startTime) -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $msg = [PSCustomObject][ordered]@{ 
-        "Execution Time (UTC)"   = $timeUTC;
-        "Execution Time (Local)" = $timeLocal; 
-        "Technique"              = $technique; 
-        "Test Number"            = $testNum; 
-        "Test Name"              = $testName; 
-        "Hostname"               = $targetHostname; 
+        "Execution Time (UTC)"   = $timeUTC
+        "Execution Time (Local)" = $timeLocal
+        "Technique"              = $technique
+        "Test Number"            = $testNum
+        "Test Name"              = $testName
+        "Hostname"               = $targetHostname
         "Username"               = $targetUser
         "GUID"                   = $testGuid
+        "ProcessId"              = $res.ProcessId
+        "ExitCode"               = $res.ExitCode
     } 
     
     $msg | Export-Csv -Path $LogPath -NoTypeInformation -Append

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -117,11 +117,10 @@ function Invoke-AtomicRunner {
         function Get-TimingVariable ($sched) {
             $atcount = $sched.Count
             if ($null -eq $atcount) { $atcount = 1 }
-            $weeklyminutes = $artConfig.scheduleTimeSpan.TotalSeconds
-            $sleeptime = ($weeklyminutes / $atcount) #in minutes
-            if ($sleeptime -gt 90 * 60) {
-                $sleeptime = 90 * 60
-            }
+            $scheduleTimeSpanSeconds = $artConfig.scheduleTimeSpan.TotalSeconds
+            $secondsForAllTestsToComplete =  = $scheduleTimeSpanSeconds
+            $sleeptime = ($secondsForAllTestsToComplete / $atcount) - 120 # 1 minute for restart and 1 minute delay for scheduled task
+            if ($sleeptime -lt 120) { $sleeptime = 120 }
             return $sleeptime
         }
 

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -29,7 +29,7 @@ function Invoke-AtomicRunner {
         $TestGuids,
 
         [Parameter(Mandatory = $false)]
-        $scheduleCSV
+        $listOfAtomics
     )
     Begin { }
     Process {       
@@ -135,7 +135,7 @@ function Invoke-AtomicRunner {
         }
 
 
-        $schedule = Get-Schedule $scheduleCSV
+        $schedule = Get-Schedule $listOfAtomics
         # If the schedule is empty, end process
         if (-not $schedule) {
             LogRunnerMsg "No test guid's or enabled tests."
@@ -146,8 +146,8 @@ function Invoke-AtomicRunner {
         $SleepTillCleanup = Get-TimingVariable $schedule
 
         # Perform cleanup, Showdetails or Prereq stuff for all scheduled items and then exit
-        if ($Cleanup -or $ShowDetails -or $CheckPrereqs -or $ShowDetailsBrief -or $GetPrereqs -or $scheduleCSV) {
-            $PSBoundParameters.Remove('scheduleCSV') | Out-Null
+        if ($Cleanup -or $ShowDetails -or $CheckPrereqs -or $ShowDetailsBrief -or $GetPrereqs -or $listOfAtomics) {
+            $PSBoundParameters.Remove('listOfAtomics') | Out-Null
             $schedule | ForEach-Object {
                 Invoke-AtomicTestFromScheduleRow $_ $PSBoundParameters
             }

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -1,0 +1,197 @@
+function Invoke-AtomicRunner {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        PositionalBinding = $false,
+        ConfirmImpact = 'Medium')]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $ShowDetails,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $CheckPrereqs,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $GetPrereqs,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $Cleanup,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $ShowDetailsBrief,
+
+        [Parameter(Mandatory = $false)]
+        [String[]]
+        $TestGuids
+    )
+    Begin { }
+    Process {       
+
+        function Get-GuidFromHostName( $basehostname ) {
+            $guid = [System.Net.Dns]::GetHostName() -replace $($basehostname + "-"), ""
+
+            if (!$guid) {
+                LogRunnerMsg "Hostname has not been updated or could not parse out the Guid: " + $guid
+                return
+            }
+            
+            # Confirm hostname contains a guid
+            [regex]$guidRegex = '(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$'
+
+            if ($guid -match $guidRegex) { return $guid } else { return "" }
+        }
+
+        function Convert-StringtoHT ($htstring) {
+            $pattern = '@\{[ ]*\"(?<Key>.*?)\"[ ]*=[ ]*\"(?<Value>.*?)\"[ ]*}'
+            $hashTable = @{ }
+            foreach ($match in [regex]::Matches($htstring, $pattern)) {
+                $hashTable[$match.Groups['Key'].Value] = $match.Groups['Value'].Value
+            }
+            $hashTable
+        }
+
+        function Invoke-AtomicTestFromScheduleRow ($tr, $psb) {
+            if ($tr.InputArgs -eq '') {
+                $tr.InputArgs = @{ }
+            }
+            else {
+                $tr.InputArgs = Convert-StringtoHT($tr.InputArgs)
+            }
+            $sc = $tr.AtomicsFolder
+            #Run the Test based on if scheduleContext is 'private' or 'public'
+            if (($sc -eq 'public') -or ($null -eq $sc)) {
+                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPublicAtomicsFolder @psb
+            }
+            elseif ($sc -eq 'private') {
+                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPrivateAtomicsFolder @psb
+            }
+        }
+
+        function Rename-ThisComputer ($tr, $basehostname) {
+            $hash = $tr.auto_generated_guid
+
+            #Todo: do we need this cred thing if using a gMSA?
+            $newHostName = "$basehostname-$hash"
+            if ($artConfig.verbose) { LogRunnerMsg "Setting hostname to $newHostName" }
+
+            If (Test-Path $artConfig.stopFile) {
+                LogRunnerMsg "exiting script because because $($artConfig.stopFile) exists"
+                exit
+            }
+
+            if ($IsLinux) {
+                Invoke-Expression $("hostnamectl set-hostname $newHostName")
+                Invoke-Expression $("shutdown -r now")
+            }
+            else {
+                if ($debug) { LogRunnerMsg "Debug: pretending to rename the computer to $newHostName"; exit }
+                if ($artConfig.gmsaAccount) {
+                    $retry = $true; $count = 0
+                    while ($retry) { # add retry loop to avoid this occassional error "The verification of the MSA failed with error 1355"
+                        Invoke-Command -ComputerName '127.0.0.1' -ConfigurationName 'RenameRunnerEndpoint' -ScriptBlock { Rename-Computer -NewName $Using:newHostName -Force -Restart }
+                        Start-Sleep 120; $count = $count + 1
+                        if($count -gt 15) { $retry = $false}
+                    }
+                }
+                else {
+                    $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $artConfig.user, (Get-Content $artConfig.credFile | ConvertTo-SecureString)
+                    try {
+                        Rename-Computer -NewName $newHostName -Force -DomainCredential $cred -Restart -ErrorAction stop
+                    }
+                    catch {
+                        if ($artConfig.verbose) { LogRunnerMsg $_ }
+                        try { Rename-Computer -NewName $newHostName -Force -LocalCredential $cred -Restart -ErrorAction stop } catch { if ($artConfig.verbose) { LogRunnerMsg $_ } }
+                    }
+                }
+                Start-Sleep -seconds 30
+                LogRunnerMsg "uh oh, still haven't restarted - should never get to here"
+                exit
+            }
+            
+        }
+        
+        function Get-TimingVariable ($sched) {
+            $atcount = $sched.Count
+            if ($null -eq $atcount) { $atcount = 1 }
+            $weeklyminutes = $artConfig.scheduleTimeSpan.TotalSeconds
+            $sleeptime = ($weeklyminutes / $atcount) #in minutes
+            if ($sleeptime -gt 90 * 60) {
+                $sleeptime = 90 * 60
+            }
+            return $sleeptime
+        }
+
+
+        $schedule = Get-Schedule
+        # If the schedule is empty, end process
+        if (-not $schedule) {
+            LogRunnerMsg "No test guid's or active tests."
+            return
+        }
+
+        # timing variables
+        $SleepTillCleanup = Get-TimingVariable $schedule
+		    
+        # exit if file stop.txt is found
+        If (Test-Path $artConfig.stopFile) {
+            LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"
+            exit
+        }
+
+        # Perform cleanup, Showdetails or Prereq stuff for all scheduled items and then exit
+        if ($Cleanup -or $ShowDetails -or $CheckPrereqs -or $ShowDetailsBrief -or $GetPrereqs) {
+    
+            $schedule | ForEach-Object {
+                Invoke-AtomicTestFromScheduleRow $_ $PSBoundParameters
+            }
+            return
+        }
+        
+        # Find current test to run
+        $guid = Get-GuidFromHostName $artConfig.basehostname
+        if ([string]::IsNullOrWhiteSpace($guid)) {
+            LogRunnerMsg "Test Guid ($guid) was null, using next item in the schedule"
+        }
+        else {
+            if ($artConfig.verbose) { LogRunnerMsg "Found Test: $guid specified in hostname" }
+            $sp = [Collections.Generic.List[Object]]$schedule
+            $currentIndex = $sp.FindIndex( { $args[0].auto_generated_guid -eq $guid })
+            if (($null -ne $currentIndex) -and ($currentIndex -ne -1)) {
+                $tr = $schedule[$currentIndex]
+            }
+
+            if ($null -ne $tr) {
+                Invoke-AtomicTestFromScheduleRow $tr $PSBoundParameters
+                Write-Host -Fore cyan "Sleeping for $SleepTillCleanup seconds before cleaning up"; Start-Sleep -Seconds $SleepTillCleanup
+                
+                # Cleanup after running test
+                $PSBoundParameters.Add('Cleanup', $true)
+                Invoke-AtomicTestFromScheduleRow $tr $PSBoundParameters
+            }
+            else {
+                LogRunnerMsg "Could not find Test: $guid in schedule. Please update schedule to run this test."
+            }
+        }
+
+        # Load next scheduled test before renaming computer
+        $nextIndex += $currentIndex + 1     
+        if ($nextIndex -ge ($schedule.count)) {
+            $tr = $schedule[0]
+        }
+        else {
+            $tr = $schedule[$nextIndex]
+        }
+        
+        if ($null -eq $tr) { 
+            LogRunnerMsg "Could not determine the next row to execute from the schedule, Starting from 1st row"; 
+            $tr = $schedule[0] 
+        }
+
+        #Rename Computer and Restart
+        Rename-ThisComputer $tr $artConfig.basehostname 
+    }
+}

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -48,22 +48,9 @@ function Invoke-AtomicRunner {
             if ($guid -match $guidRegex) { return $guid } else { return "" }
         }
 
-        function Convert-StringtoHT ($htstring) {
-            $pattern = '@\{[ ]*\"(?<Key>.*?)\"[ ]*=[ ]*\"(?<Value>.*?)\"[ ]*}'
-            $hashTable = @{ }
-            foreach ($match in [regex]::Matches($htstring, $pattern)) {
-                $hashTable[$match.Groups['Key'].Value] = $match.Groups['Value'].Value
-            }
-            $hashTable
-        }
-
         function Invoke-AtomicTestFromScheduleRow ($tr, $psb) {
-            if ($tr.InputArgs -eq '') {
-                $tr.InputArgs = @{ }
-            }
-            else {
-                $tr.InputArgs = Convert-StringtoHT($tr.InputArgs)
-            }
+            $theArgs = $tr.InputArgs
+            $tr.InputArgs = ConvertFrom-StringData -StringData $theArgs
             $sc = $tr.AtomicsFolder
             #Run the Test based on if scheduleContext is 'private' or 'public'
             if (($sc -eq 'public') -or ($null -eq $sc)) {
@@ -205,3 +192,5 @@ function Invoke-AtomicRunner {
     
     }
 }
+
+Invoke-AtomicRunner -listOfAtomics .\IcedID.csv -ShowDetails

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -192,5 +192,3 @@ function Invoke-AtomicRunner {
     
     }
 }
-
-Invoke-AtomicRunner -listOfAtomics .\IcedID.csv -ShowDetails

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -50,7 +50,9 @@ function Invoke-AtomicRunner {
 
         function Invoke-AtomicTestFromScheduleRow ($tr, $psb) {
             $theArgs = $tr.InputArgs
-            $tr.InputArgs = ConvertFrom-StringData -StringData $theArgs
+            if ($theArgs.GetType().Name -ne "Hashtable") {
+                $tr.InputArgs = ConvertFrom-StringData -StringData $theArgs
+            }
             $sc = $tr.AtomicsFolder
             #Run the Test based on if scheduleContext is 'private' or 'public'
             if (($sc -eq 'public') -or ($null -eq $sc)) {
@@ -116,8 +118,8 @@ function Invoke-AtomicRunner {
             if ($null -eq $atcount) { $atcount = 1 }
             $scheduleTimeSpanSeconds = $artConfig.scheduleTimeSpan.TotalSeconds
             $secondsForAllTestsToComplete = $scheduleTimeSpanSeconds
-            $sleeptime = ($secondsForAllTestsToComplete / $atcount) - 120 # 1 minute for restart and 1 minute delay for scheduled task
-            if ($sleeptime -lt 120) { $sleeptime = 120 }
+            $sleeptime = ($secondsForAllTestsToComplete / $atcount) - 120 - $artConfig.kickOffDelay.TotalSeconds # 1 minute for restart and 1 minute delay for scheduled task and an optional kickoff delay
+            if ($sleeptime -lt 120) { $sleeptime = 120 } # minimum 2 minute sleep time
             return $sleeptime
         }
 

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -118,7 +118,7 @@ function Invoke-AtomicRunner {
             $atcount = $sched.Count
             if ($null -eq $atcount) { $atcount = 1 }
             $scheduleTimeSpanSeconds = $artConfig.scheduleTimeSpan.TotalSeconds
-            $secondsForAllTestsToComplete =  = $scheduleTimeSpanSeconds
+            $secondsForAllTestsToComplete = $scheduleTimeSpanSeconds
             $sleeptime = ($secondsForAllTestsToComplete / $atcount) - 120 # 1 minute for restart and 1 minute delay for scheduled task
             if ($sleeptime -lt 120) { $sleeptime = 120 }
             return $sleeptime

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -191,7 +191,9 @@ function Invoke-AtomicRunner {
             $tr = $schedule[0] 
         }
 
-        #Rename Computer and Restart
-        Rename-ThisComputer $tr $artConfig.basehostname 
+        if (-not $artConfig.skipRenameAndRestart) {
+            #Rename Computer and Restart
+            Rename-ThisComputer $tr $artConfig.basehostname
+        }
     }
 }

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -69,7 +69,7 @@ function Invoke-AtomicRunner {
             if ($artConfig.verbose) { LogRunnerMsg "Setting hostname to $newHostName" }
 
             If (Test-Path $artConfig.stopFile) {
-                LogRunnerMsg "exiting script because because $($artConfig.stopFile) exists"
+                LogRunnerMsg "exiting script because $($artConfig.stopFile) exists"
                 exit
             }
 
@@ -144,6 +144,7 @@ function Invoke-AtomicRunner {
         # exit if file stop.txt is found
         If (Test-Path $artConfig.stopFile) {
             LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"
+            Write-Host -ForegroundColor Yellow "Exiting script because $($artConfig.stopFile) does exist."; Start-Sleep 10;
             exit
         }
         

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -128,7 +128,7 @@ function Invoke-AtomicRunner {
         $schedule = Get-Schedule
         # If the schedule is empty, end process
         if (-not $schedule) {
-            LogRunnerMsg "No test guid's or active tests."
+            LogRunnerMsg "No test guid's or enabled tests."
             return
         }
 

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -91,10 +91,11 @@ function Invoke-AtomicRunner {
                 if ($debug) { LogRunnerMsg "Debug: pretending to rename the computer to $newHostName"; exit }
                 if ($artConfig.gmsaAccount) {
                     $retry = $true; $count = 0
-                    while ($retry) { # add retry loop to avoid this occassional error "The verification of the MSA failed with error 1355"
+                    while ($retry) {
+                        # add retry loop to avoid this occassional error "The verification of the MSA failed with error 1355"
                         Invoke-Command -ComputerName '127.0.0.1' -ConfigurationName 'RenameRunnerEndpoint' -ScriptBlock { Rename-Computer -NewName $Using:newHostName -Force -Restart }
                         Start-Sleep 120; $count = $count + 1
-                        if($count -gt 15) { $retry = $false}
+                        if ($count -gt 15) { $retry = $false }
                     }
                 }
                 else {
@@ -134,12 +135,6 @@ function Invoke-AtomicRunner {
 
         # timing variables
         $SleepTillCleanup = Get-TimingVariable $schedule
-		    
-        # exit if file stop.txt is found
-        If (Test-Path $artConfig.stopFile) {
-            LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"
-            exit
-        }
 
         # Perform cleanup, Showdetails or Prereq stuff for all scheduled items and then exit
         if ($Cleanup -or $ShowDetails -or $CheckPrereqs -or $ShowDetailsBrief -or $GetPrereqs) {
@@ -148,6 +143,12 @@ function Invoke-AtomicRunner {
                 Invoke-AtomicTestFromScheduleRow $_ $PSBoundParameters
             }
             return
+        }
+
+        # exit if file stop.txt is found
+        If (Test-Path $artConfig.stopFile) {
+            LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"
+            exit
         }
         
         # Find current test to run

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -149,11 +149,9 @@ function Invoke-AtomicTest {
 
         Function Get-Logger {
             Param([string]$name)
-            if(-not(Get-Module -name $name))
-            {
-                if(Get-Module -ListAvailable |
-                    Where-Object { $_.name -eq $name })
-                {
+            if (-not(Get-Module -name $name)) {
+                if (Get-Module -ListAvailable |
+                    Where-Object { $_.name -eq $name }) {
                     Import-Module -Name $name -Force
                     $true
                 } #end if module available then import
@@ -167,130 +165,149 @@ function Invoke-AtomicTest {
         } #end function Get-Logger
 
         $isLoggingModuleSet = $false
-        if(-not $NoExecutionLog) {
+        if (-not $NoExecutionLog) {
             $isLoggingModuleSet = $true
-            if(-not $PSBoundParameters.ContainsKey('LoggingModule')) {
-                Import-Module "$PSScriptRoot\Default-ExecutionLogger.psm1" -Force
-                $LoggingModule = "Default-ExecutionLogger"
-            } else {
+            if (-not $PSBoundParameters.ContainsKey('LoggingModule')) {
+                # use the syslog logger as default if the server and port are configured in the config file
+                if ([bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
+                    Import-Module "$PSScriptRoot\Syslog-ExecutionLogger.psm1" -Force
+                    $LoggingModule = "Syslog-ExecutionLogger"
+                }
+                else {
+                    Import-Module "$PSScriptRoot\Default-ExecutionLogger.psm1" -Force
+                    $LoggingModule = "Default-ExecutionLogger"
+                }
+            } 
+            else {
                 Remove-Module -Name "Default-ExecutionLogger" -erroraction silentlycontinue
+                if (($PSBoundParameters['LoggingModule'] -eq "Syslog-ExecutionLogger") -and [bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
+                    Import-Module "$PSScriptRoot\Syslog-ExecutionLogger.psm1" -Force
+                    $LoggingModule = "Syslog-ExecutionLogger"
+                }
+                else {
+                    Remove-Module -Name "Syslog-ExecutionLogger" -erroraction silentlycontinue
+                }
             }
         }
 
-        if($isLoggingModuleSet) {
-            if(Get-Logger -name $LoggingModule) {
+        if ($isLoggingModuleSet) {
+            if (Get-Logger -name $LoggingModule) {
                 Write-Verbose "Using Logger: $LoggingModule"
-            } else {
+            }
+            else {
                 Write-Host "Logger not found: ", $LoggingModule
             }
 
-            if((Get-Command Start-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
-                if((Get-Command Write-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
-                    if((Get-Command Stop-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
+            if ((Get-Command Start-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
+                if ((Get-Command Write-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
+                    if ((Get-Command Stop-ExecutionLog -erroraction silentlycontinue).Source -eq $LoggingModule) {
                         Write-Verbose "All logging commands found"
-                    } else {
+                    }
+                    else {
                         Write-Host "Stop-ExecutionLog not found or loaded from the wrong module"
                         return
                     }
-                } else {
+                }
+                else {
                     Write-Host "Write-ExecutionLog not found or loaded from the wrong module"
                     return
                 }
-            } else {
+            }
+            else {
                 Write-Host "Start-ExecutionLog not found or loaded from the wrong module"
                 return
             }
         }
 
-        if($isLoggingModuleSet) {
+        if ($isLoggingModuleSet) {
             # Since there might a comma(T1559-1,2,3) Powershell takes it as array.
             # So converting it back to string.
-            if($AtomicTechnique -is [array]) {
+            if ($AtomicTechnique -is [array]) {
                 $AtomicTechnique = $AtomicTechnique -join ","
             }
             
             # Splitting Atomic Technique short form into technique and test numbers.
-            $AtomicTechniqueParams =  ($AtomicTechnique -split '-')
+            $AtomicTechniqueParams = ($AtomicTechnique -split '-')
             $AtomicTechnique = $AtomicTechniqueParams[0]
 
-            if($AtomicTechniqueParams.Length -gt 1){
+            if ($AtomicTechniqueParams.Length -gt 1) {
                 $ShortTestNumbers = $AtomicTechniqueParams[-1]
             }
 
-            if($TestNumbers -eq $null -and $ShortTestNumbers -ne $null) {
+            if ($TestNumbers -eq $null -and $ShortTestNumbers -ne $null) {
                 $TestNumbers = $ShortTestNumbers -split ','
             }
             
             # Here we're rebuilding an equivalent command line to put in the logs
             $commandLine = "Invoke-AtomicTest $AtomicTechnique"
 
-            if($ShowDetails -ne $false) {
+            if ($ShowDetails -ne $false) {
                 $commandLine = "$commandLine -ShowDetails $ShowDetails"
             }
 
-            if($ShowDetailsBrief -ne $false) {
+            if ($ShowDetailsBrief -ne $false) {
                 $commandLine = "$commandLine -ShowDetailsBrief $ShowDetailsBrief"
             }
 
-            if($TestNumbers -ne $null) {
+            if ($TestNumbers -ne $null) {
                 $commandLine = "$commandLine -TestNumbers $TestNumbers"
             }
 
-            if($TestNames -ne $null) {
+            if ($TestNames -ne $null) {
                 $commandLine = "$commandLine -TestNames $TestNames"
             }
 
-            if($TestGuids -ne $null) {
+            if ($TestGuids -ne $null) {
                 $commandLine = "$commandLine -TestGuids $TestGuids"
             }
 
             $commandLine = "$commandLine -PathToAtomicsFolder $PathToAtomicsFolder"
 
-            if($CheckPrereqs -ne $false) {
+            if ($CheckPrereqs -ne $false) {
                 $commandLine = "$commandLine -CheckPrereqs $CheckPrereqs"
             }
 
-            if($PromptForInputArgs -ne $false) {
+            if ($PromptForInputArgs -ne $false) {
                 $commandLine = "$commandLine -PromptForInputArgs $PromptForInputArgs"
             }
 
-            if($GetPrereqs -ne $false) {
+            if ($GetPrereqs -ne $false) {
                 $commandLine = "$commandLine -GetPrereqs $GetPrereqs"
             }
 
-            if($Cleanup -ne $false) {
+            if ($Cleanup -ne $false) {
                 $commandLine = "$commandLine -Cleanup $Cleanup"
             }
 
-            if($NoExecutionLog -ne $false) {
+            if ($NoExecutionLog -ne $false) {
                 $commandLine = "$commandLine -NoExecutionLog $NoExecutionLog"
             }
 
             $commandLine = "$commandLine -ExecutionLogPath $ExecutionLogPath"
 
-            if($Force -ne $false) {
+            if ($Force -ne $false) {
                 $commandLine = "$commandLine -Force $Force"
             }
 
-            if($InputArgs -ne $null) {
+            if ($InputArgs -ne $null) {
                 $commandLine = "$commandLine -InputArgs $InputArgs"
             }
 
             $commandLine = "$commandLine -TimeoutSeconds $TimeoutSeconds"
 
-            if($Session -ne $null) {
+            if ($Session -ne $null) {
                 $commandLine = "$commandLine -Session $Session"
             }
 
-            if($Interactive -ne $false) {
+            if ($Interactive -ne $false) {
                 $commandLine = "$commandLine -Interactive $Interactive"
             }
 
-            if($KeepStdOutStdErrFiles -ne $false) {
+            if ($KeepStdOutStdErrFiles -ne $false) {
                 $commandLine = "$commandLine -KeepStdOutStdErrFiles $KeepStdOutStdErrFiles"
             }
 
-            if($LoggingModule -ne $null) {
+            if ($LoggingModule -ne $null) {
                 $commandLine = "$commandLine -LoggingModule $LoggingModule"
             }
 
@@ -485,7 +502,7 @@ function Invoke-AtomicTest {
                         $final_command = Merge-InputArgs $test.executor.command $test $InputArgs $PathToPayloads
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name $executionPlatform $TimeoutSeconds $session -Interactive:$Interactive
                         $stopTime = Get-Date
-                        if($isLoggingModuleSet) {
+                        if ($isLoggingModuleSet) {
                             Write-ExecutionLog $startTime $stopTime $AT $order $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res.StandardOutput $res.ErrorOutput (-Not($IsLinux -or $IsMacOS))
                             $order++
                         }
@@ -514,7 +531,7 @@ function Invoke-AtomicTest {
             Invoke-AtomicTestSingle $AtomicTechnique
         }
 
-        if($isLoggingModuleSet) {
+        if ($isLoggingModuleSet) {
             Stop-ExecutionLog $startTime $ExecutionLogPath $executionHostname $executionUser (-Not($IsLinux -or $IsMacOS))
         }
 

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -503,7 +503,7 @@ function Invoke-AtomicTest {
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name $executionPlatform $TimeoutSeconds $session -Interactive:$Interactive
                         $stopTime = Get-Date
                         if ($isLoggingModuleSet) {
-                            Write-ExecutionLog $startTime $stopTime $AT $order $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res.StandardOutput $res.ErrorOutput (-Not($IsLinux -or $IsMacOS))
+                            Write-ExecutionLog $startTime $stopTime $AT $order $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res (-Not($IsLinux -or $IsMacOS))
                             $order++
                         }
                         Write-KeyValue "Done executing test: " $testId

--- a/Public/Invoke-KickoffAtomicRunner.ps1
+++ b/Public/Invoke-KickoffAtomicRunner.ps1
@@ -41,7 +41,12 @@ function Invoke-KickoffAtomicRunner {
     Rotate-Log $log $max_filesize $max_file_age #no need to repeat this. Can reduce further.
 
     # Invoke the Runner Script
-    Invoke-AtomicRunner *>> $all_log_file
+    if ($artConfig.debug) {
+        Invoke-AtomicRunner *>> $all_log_file
+    }
+    else {
+        Invoke-AtomicRunner
+    }
 }
 
 function LogRunnerMsg ($message) {

--- a/Public/Invoke-KickoffAtomicRunner.ps1
+++ b/Public/Invoke-KickoffAtomicRunner.ps1
@@ -40,6 +40,9 @@ function Invoke-KickoffAtomicRunner {
     $log = get-item $artConfig.logFile
     Rotate-Log $log $max_filesize $max_file_age #no need to repeat this. Can reduce further.
 
+    # Update the AtomicRedTeam,Invoke-AtomicRedTeam and Schedule code if configured to do so.
+    Invoke-CodeAndScheduleRefresh
+
     # Invoke the Runner Script
     Invoke-AtomicRunner *>> $all_log_file
 }
@@ -48,4 +51,16 @@ function LogRunnerMsg ($message) {
     $now = "[{0:MM/dd/yy} {0:HH:mm:ss}]" -f (Get-Date)
     Write-Host -fore cyan $message
     Add-Content $artConfig.logFile "$now`: $message"
+}
+
+function Invoke-CodeAndScheduleRefresh() {
+
+    # just return if we aren't at the beginning of the schedule
+
+    # update the atomics (no payloads)
+
+    # update the execution framework (Invoke-AtomicRedTeam)
+
+    # update the schedule
+
 }

--- a/Public/Invoke-KickoffAtomicRunner.ps1
+++ b/Public/Invoke-KickoffAtomicRunner.ps1
@@ -40,6 +40,9 @@ function Invoke-KickoffAtomicRunner {
     $log = get-item $artConfig.logFile
     Rotate-Log $log $max_filesize $max_file_age #no need to repeat this. Can reduce further.
 
+    # Optional additional delay before starting
+    Start-Sleep $artConfig.kickOffDelay.TotalSeconds
+
     # Invoke the Runner Script
     if ($artConfig.debug) {
         Invoke-AtomicRunner *>> $all_log_file

--- a/Public/Invoke-KickoffAtomicRunner.ps1
+++ b/Public/Invoke-KickoffAtomicRunner.ps1
@@ -1,0 +1,51 @@
+function Invoke-KickoffAtomicRunner {
+
+    #log rotation function
+    function Rotate-Log {
+        Param ($log, $max_filesize, $max_age)
+        $datetime = Get-Date -uformat "%Y-%m-%d-%H%M"
+
+        if ($log.Length / 1MB -ge $max_filesize) { 
+            Write-Host "file named $($log.name) is bigger than $max_filesize MB"
+            $newname = "$($log.Name)_${datetime}.arclog"
+            Rename-Item $log.PSPath $newname
+            Write-Host "Done rotating file" 
+        }
+
+        $logdir_content = Get-ChildItem $artConfig.atomicLogsPath -filter "*.arclog"
+        $cutoff_date = (get-date).AddDays($max_age)
+        $logdir_content | ForEach-Object { 
+            if ($_.LastWriteTime -gt $cutoff_date) {
+                Remove-Item $_
+                Write-Host "Removed $($_.PSPath)"
+            }
+        }
+    }
+
+    #Check if logfiles exist. If not create them.
+    $all_log_file = Join-Path $artConfig.atomicLogsPath "all-out-$($artConfig.basehostname).txt"
+    if ($False -eq (Test-Path $all_log_file)) {
+        New-Item $all_log_file -ItemType File -Force
+    }
+    if ($False -eq (Test-Path $artConfig.logFile)) {
+        New-Item $artConfig.logFile -ItemType File -Force
+    }
+
+
+    #Rotate logs based on FileSize and Date max_filesize
+    $max_filesize = 200 #in MB
+    $max_file_age = 30 #in days
+    $log = get-item $all_log_file
+    Rotate-Log $log $max_filesize $max_file_age
+    $log = get-item $artConfig.logFile
+    Rotate-Log $log $max_filesize $max_file_age #no need to repeat this. Can reduce further.
+
+    # Invoke the Runner Script
+    Invoke-AtomicRunner *>> $all_log_file
+}
+
+function LogRunnerMsg ($message) {
+    $now = "[{0:MM/dd/yy} {0:HH:mm:ss}]" -f (Get-Date)
+    Write-Host -fore cyan $message
+    Add-Content $artConfig.logFile "$now`: $message"
+}

--- a/Public/Invoke-KickoffAtomicRunner.ps1
+++ b/Public/Invoke-KickoffAtomicRunner.ps1
@@ -40,9 +40,6 @@ function Invoke-KickoffAtomicRunner {
     $log = get-item $artConfig.logFile
     Rotate-Log $log $max_filesize $max_file_age #no need to repeat this. Can reduce further.
 
-    # Update the AtomicRedTeam,Invoke-AtomicRedTeam and Schedule code if configured to do so.
-    Invoke-CodeAndScheduleRefresh
-
     # Invoke the Runner Script
     Invoke-AtomicRunner *>> $all_log_file
 }
@@ -51,16 +48,4 @@ function LogRunnerMsg ($message) {
     $now = "[{0:MM/dd/yy} {0:HH:mm:ss}]" -f (Get-Date)
     Write-Host -fore cyan $message
     Add-Content $artConfig.logFile "$now`: $message"
-}
-
-function Invoke-CodeAndScheduleRefresh() {
-
-    # just return if we aren't at the beginning of the schedule
-
-    # update the atomics (no payloads)
-
-    # update the execution framework (Invoke-AtomicRedTeam)
-
-    # update the schedule
-
 }

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -43,7 +43,7 @@ function Get-NewSchedule() {
         $privateAtomics = Loop $privateAtomicFiles "Private"
     }
     else {
-        Write-Host -ForegroundColor Yellow "Private Atomics Folder not Found $($artConfig.PathToPrivateAtomicsFolder)"
+        Write-Verbose "Private Atomics Folder not Found $($artConfig.PathToPrivateAtomicsFolder)"
     }
     $AllAtomicTests = New-Object System.Collections.ArrayList
     try { $AllAtomicTests.AddRange($publicAtomics) }catch {}

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -53,7 +53,7 @@ function Get-NewSchedule() {
 
 function Get-ScheduleRefresh() {
     $AllAtomicTests = Get-NewSchedule
-    $schedule = Get-Schedule $false # get schedule, including inactive (ie not filtered)
+    $schedule = Get-Schedule $null $false # get schedule, including inactive (ie not filtered)
             
     # Creating new schedule object for updating changes in atomics
     $newSchedule = New-Object System.Collections.ArrayList
@@ -101,7 +101,8 @@ function Get-Schedule($scheduleCSV, $filtered = $true, $testGuids = $null) {
     if ($scheduleCSV -or (Test-Path($artConfig.scheduleFile))) {
         if ($scheduleCSV) {
             $schedule = Import-Csv $scheduleCSV
-        }else {
+        }
+        else {
             $schedule = Import-Csv $artConfig.scheduleFile
         }
     
@@ -127,6 +128,10 @@ function Get-Schedule($scheduleCSV, $filtered = $true, $testGuids = $null) {
 }
 
 function Invoke-GenerateNewSchedule() {
+    #create AtomicRunner-Logs directories if they don't exist
+    New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
+    New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore
+
     LogRunnerMsg "Generating new schedule: $($artConfig.scheduleFile)"
     $schedule = Get-NewSchedule
     $schedule | Export-Csv $artConfig.scheduleFile -NoTypeInformation

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -77,12 +77,15 @@ function Get-ScheduleRefresh() {
                             `nCannot Continue Execution. System Exit"
                 exit
             }
+            $old.Order = $fresh.Order
             $old.Technique = $fresh.Technique
             $old.TestName = $fresh.TestName
             $old.supported_platforms = $fresh.supported_platforms
             $old.TimeoutSeconds = $fresh.TimeoutSeconds
             $old.InputArgs = $fresh.InputArgs
-            $old.hostname = $fresh.hostname
+            $old.AtomicsFolder = $fresh.AtomicsFolder
+            $old.enabled = $fresh.enabled
+            $old.notes = $fresh.notes
                     
             $update = $true
             $newSchedule += $old

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -96,10 +96,10 @@ function Get-ScheduleRefresh() {
 
 }
 
-function Get-Schedule($scheduleCSV, $filtered = $true, $testGuids = $null) {
-    if ($scheduleCSV -or (Test-Path($artConfig.scheduleFile))) {
-        if ($scheduleCSV) {
-            $schedule = Import-Csv $scheduleCSV
+function Get-Schedule($listOfAtomics, $filtered = $true, $testGuids = $null) {
+    if ($listOfAtomics -or (Test-Path($artConfig.scheduleFile))) {
+        if ($listOfAtomics) {
+            $schedule = Import-Csv $listOfAtomics
         }
         else {
             $schedule = Import-Csv $artConfig.scheduleFile

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -75,6 +75,8 @@ function Get-ScheduleRefresh() {
                 $fresh = $fresh[0]
                 LogRunnerMsg "Duplicated auto_generated_guid found $($fresh.auto_generated_guid) with technique $($fresh.Technique). 
                             `nCannot Continue Execution. System Exit"
+                Write-Host -ForegroundColor Yellow "Duplicated auto_generated_guid found $($fresh.auto_generated_guid) with technique $($fresh.Technique). 
+                            `nCannot Continue Execution. System Exit"; Start-Sleep 10
                 exit
             }
             $old.Order = $fresh.Order

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -17,8 +17,7 @@ function Loop($fileList, $atomicType) {
                     $test | Add-Member -MemberType NoteProperty -Name TimeoutSeconds -Value 120
                     $test | Add-Member -MemberType NoteProperty -Name InputArgs -Value ""
                     $test | Add-Member -MemberType NoteProperty -Name AtomicsFolder -Value $atomicType
-                    $test | Add-Member -MemberType NoteProperty -Name hostname -Value ""
-                    $test | Add-Member -MemberType NoteProperty -Name active -Value $false
+                    $test | Add-Member -MemberType NoteProperty -Name enabled -Value $false
                     $test | Add-Member -MemberType NoteProperty -Name notes -Value ""
 
                     # Added dummy variable to grab the index values returned by appending to an arraylist so they don't get written to the screen
@@ -111,7 +110,7 @@ function Get-Schedule($filtered = $true, $testGuids = $null) {
         }
         elseif ($filtered) {
             $schedule = $schedule | Where-Object {
-                ($_.active -eq $true -and ($_.supported_platforms -like "*" + $artConfig.OS + "*" ))
+                ($_.enabled -eq $true -and ($_.supported_platforms -like "*" + $artConfig.OS + "*" ))
             }
         }
 
@@ -120,7 +119,7 @@ function Get-Schedule($filtered = $true, $testGuids = $null) {
         Write-Host -ForegroundColor Yellow "Couldn't find schedule file ($($artConfig.scheduleFile)) Update the path to the schedule file in the config or generate a new one with 'Invoke-GenerateNewSchedule'"
     }
                 
-    if ($schedule.length -eq 0) { Write-Host -ForegroundColor Yellow "No active tests were found. Edit the 'active' column of your schedule file ($($artConfig.scheduleFile)) and set some to active (True)"; return $null }
+    if ($schedule.length -eq 0) { Write-Host -ForegroundColor Yellow "No active tests were found. Edit the 'enabled' column of your schedule file ($($artConfig.scheduleFile)) and set some to enabled (True)"; return $null }
     return $schedule
 }
 

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -97,10 +97,13 @@ function Get-ScheduleRefresh() {
 
 }
 
-function Get-Schedule($filtered = $true, $testGuids = $null) {
-    # Read schedule file, if it doesn't exist pull from Atomics
-    if (Test-Path($artConfig.scheduleFile)) {
-        $schedule = Import-Csv $artConfig.scheduleFile
+function Get-Schedule($scheduleCSV, $filtered = $true, $testGuids = $null) {
+    if ($scheduleCSV -or (Test-Path($artConfig.scheduleFile))) {
+        if ($scheduleCSV) {
+            $schedule = Import-Csv $scheduleCSV
+        }else {
+            $schedule = Import-Csv $artConfig.scheduleFile
+        }
     
         # Filter schedule to either Active/Supported Platform or TestGuids List
         if ($TestGuids) {
@@ -119,7 +122,7 @@ function Get-Schedule($filtered = $true, $testGuids = $null) {
         Write-Host -ForegroundColor Yellow "Couldn't find schedule file ($($artConfig.scheduleFile)) Update the path to the schedule file in the config or generate a new one with 'Invoke-GenerateNewSchedule'"
     }
                 
-    if ($schedule.length -eq 0) { Write-Host -ForegroundColor Yellow "No active tests were found. Edit the 'enabled' column of your schedule file ($($artConfig.scheduleFile)) and set some to enabled (True)"; return $null }
+    if (($null -eq $schedule) -or ($schedule.length -eq 0)) { Write-Host -ForegroundColor Yellow "No active tests were found. Edit the 'enabled' column of your schedule file and set some to enabled (True)"; return $null }
     return $schedule
 }
 

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -1,0 +1,139 @@
+# Loop through all atomic yaml files to load into list of objects
+function Loop($fileList, $atomicType) {
+    $AllAtomicTests = New-Object System.Collections.ArrayList
+
+    $fileList | ForEach-Object {
+        $currentTechnique = [System.IO.Path]::GetFileNameWithoutExtension($_.FullName)
+        if ( $currentTechnique -ne "index" ) { 
+            $technique = Get-AtomicTechnique -Path $_.FullName
+            if ($technique) {                                
+                $technique.atomic_tests | ForEach-Object -Process {
+                    $test = New-Object -TypeName psobject
+                    $test | Add-Member -MemberType NoteProperty -Name Order -Value $null
+                    $test | Add-Member -MemberType NoteProperty -Name Technique -Value ($technique.attack_technique -join "|")
+                    $test | Add-Member -MemberType NoteProperty -Name TestName -Value $_.name
+                    $test | Add-Member -MemberType NoteProperty -Name auto_generated_guid -Value $_.auto_generated_guid
+                    $test | Add-Member -MemberType NoteProperty -Name supported_platforms -Value ($_.supported_platforms -join "|")
+                    $test | Add-Member -MemberType NoteProperty -Name TimeoutSeconds -Value 120
+                    $test | Add-Member -MemberType NoteProperty -Name InputArgs -Value ""
+                    $test | Add-Member -MemberType NoteProperty -Name AtomicsFolder -Value $atomicType
+                    $test | Add-Member -MemberType NoteProperty -Name hostname -Value ""
+                    $test | Add-Member -MemberType NoteProperty -Name active -Value $false
+                    $test | Add-Member -MemberType NoteProperty -Name notes -Value ""
+
+                    # Added dummy variable to grab the index values returned by appending to an arraylist so they don't get written to the screen
+                    $dummy = $AllAtomicTests.Add(($test))
+                }
+            }
+        }
+    }
+    return $AllAtomicTests
+
+}
+    
+function Get-NewSchedule() {
+    if (Test-Path $artConfig.PathToPublicAtomicsFolder) {
+        $publicAtomicFiles = Get-ChildItem $artConfig.PathToPublicAtomicsFolder -Recurse -Exclude Indexes -Filter T*.yaml -File 
+        $publicAtomics = Loop $publicAtomicFiles "Public"
+    }
+    else {
+        Write-Host -ForegroundColor Yellow "Public Atomics Folder not Found $($artConfig.PathToPublicAtomicsFolder)"
+    }
+    if (Test-Path $artConfig.PathToPrivateAtomicsFolder) {
+        $privateAtomicFiles = Get-ChildItem $artConfig.PathToPrivateAtomicsFolder -Recurse -Exclude Indexes -Filter T*.yaml  -File 
+        $privateAtomics = Loop $privateAtomicFiles "Private"
+    }
+    else {
+        Write-Host -ForegroundColor Yellow "Private Atomics Folder not Found $($artConfig.PathToPrivateAtomicsFolder)"
+    }
+    $AllAtomicTests = New-Object System.Collections.ArrayList
+    try { $AllAtomicTests.AddRange($publicAtomics) }catch {}
+    try { $AllAtomicTests.AddRange($privateAtomics) }catch {}
+    return $AllAtomicTests
+}
+
+function Get-ScheduleRefresh() {
+    $AllAtomicTests = Get-NewSchedule
+    $schedule = Get-Schedule $false # get schedule, including inactive (ie not filtered)
+            
+    # Creating new schedule object for updating changes in atomics
+    $newSchedule = New-Object System.Collections.ArrayList
+
+    # Check if any tests haven't been added to schedule and add them
+    $update = $false
+    foreach ($guid in $AllAtomicTests | Select-Object -ExpandProperty auto_generated_guid) {
+        $fresh = $AllAtomicTests | Where-Object { $_.auto_generated_guid -eq $guid }
+        $old = $schedule | Where-Object { $_.auto_generated_guid -eq $guid }
+
+        if (!$old) {
+            $update = $true
+            $newSchedule += $fresh
+        }
+              
+        # Updating schedule with changes
+        else {
+            if ($fresh -is [array]) {
+                $fresh = $fresh[0]
+                LogRunnerMsg "Duplicated auto_generated_guid found $($fresh.auto_generated_guid) with technique $($fresh.Technique). 
+                            `nCannot Continue Execution. System Exit"
+                exit
+            }
+            $old.Technique = $fresh.Technique
+            $old.TestName = $fresh.TestName
+            $old.supported_platforms = $fresh.supported_platforms
+            $old.TimeoutSeconds = $fresh.TimeoutSeconds
+            $old.InputArgs = $fresh.InputArgs
+            $old.hostname = $fresh.hostname
+                    
+            $update = $true
+            $newSchedule += $old
+        }
+              
+    }
+    if ($update) {
+        $newSchedule | Export-Csv $artConfig.scheduleFile
+        LogRunnerMsg "Schedule has been updated with new tests."
+    }
+    return $newSchedule
+
+}
+
+function Get-Schedule($filtered = $true, $testGuids = $null) {
+    # Read schedule file, if it doesn't exist pull from Atomics
+    if (Test-Path($artConfig.scheduleFile)) {
+        $schedule = Import-Csv $artConfig.scheduleFile
+    
+        # Filter schedule to either Active/Supported Platform or TestGuids List
+        if ($TestGuids) {
+            $schedule = $schedule | Where-Object {
+                ($Null -ne $TestGuids -and $TestGuids -contains $_.auto_generated_guid)  
+            }
+        }
+        elseif ($filtered) {
+            $schedule = $schedule | Where-Object {
+                ($_.active -eq $true -and ($_.supported_platforms -like "*" + $artConfig.OS + "*" ))
+            }
+        }
+
+    }
+    else {
+        Write-Host -ForegroundColor Yellow "Couldn't find schedule file ($($artConfig.scheduleFile)) Update the path to the schedule file in the config or generate a new one with 'Invoke-GenerateNewSchedule'"
+    }
+                
+    if ($schedule.length -eq 0) { Write-Host -ForegroundColor Yellow "No active tests were found. Edit the 'active' column of your schedule file ($($artConfig.scheduleFile)) and set some to active (True)"; return $null }
+    return $schedule
+}
+
+function Invoke-GenerateNewSchedule() {
+    LogRunnerMsg "Generating new schedule: $($artConfig.scheduleFile)"
+    $schedule = Get-NewSchedule
+    $schedule | Export-Csv $artConfig.scheduleFile -NoTypeInformation
+    Write-Host -ForegroundColor Green "Schedule written to $($artConfig.scheduleFile)"
+}
+
+function Invoke-RefreshExistingSchedule() {
+    LogRunnerMsg "Refreshing existing schedule: $($artConfig.scheduleFile)"
+    $schedule = Get-ScheduleRefresh
+    $schedule | Export-Csv $artConfig.scheduleFile -NoTypeInformation
+    Write-Host -ForegroundColor Green "Refreshed schedule written to $($artConfig.scheduleFile)"
+}

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -129,8 +129,8 @@ function Get-Schedule($scheduleCSV, $filtered = $true, $testGuids = $null) {
 
 function Invoke-GenerateNewSchedule() {
     #create AtomicRunner-Logs directories if they don't exist
-    New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
-    New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore
+    New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore | Out-Null
+    New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore | Out-Null
 
     LogRunnerMsg "Generating new schedule: $($artConfig.scheduleFile)"
     $schedule = Get-NewSchedule

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -79,15 +79,9 @@ function Get-ScheduleRefresh() {
                             `nCannot Continue Execution. System Exit"; Start-Sleep 10
                 exit
             }
-            $old.Order = $fresh.Order
             $old.Technique = $fresh.Technique
             $old.TestName = $fresh.TestName
             $old.supported_platforms = $fresh.supported_platforms
-            $old.TimeoutSeconds = $fresh.TimeoutSeconds
-            $old.InputArgs = $fresh.InputArgs
-            $old.AtomicsFolder = $fresh.AtomicsFolder
-            $old.enabled = $fresh.enabled
-            $old.notes = $fresh.notes
                     
             $update = $true
             $newSchedule += $old

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -1,5 +1,6 @@
-function Invoke-SetupAtomicRunner {
+#Requires -RunAsAdministrator
 
+function Invoke-SetupAtomicRunner {
     #create AtomicRunner-Logs directory if it doesn't exist
     New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
     New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -67,7 +67,7 @@ function Invoke-SetupAtomicRunner {
         # sets cronjob string using basepath from config.ps1
         $pwshPath = which pwsh
         $job = "@reboot root $pwshPath -Command Invoke-KickoffAtomicRunner"
-        $exists = cat /etc/crontab|Select-String -Quiet "KickoffAtomicRunner"
+        $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
         if ($null -eq $exists) {
             $(echo "$job" >> /etc/crontab)
@@ -82,10 +82,8 @@ function Invoke-SetupAtomicRunner {
     $root = Split-Path $PSScriptRoot -Parent
     $pathToPSD1 = Join-Path $root "Invoke-AtomicRedTeam.psd1"
     $importStatement = "Import-Module ""$pathToPSD1"" -Force"
-    $profileContent = ""
-    if (Test-Path -Path $profile) { #read in $profile if it exists
-        $profileContent = Get-Content $profile
-    }
+    New-Item $PROFILE -ErrorAction Ignore
+    $profileContent = Get-Content $profile
     $line = $profileContent | Select-String ".*import-module.*invoke-atomicredTeam.psd1" | Select-Object -ExpandProperty Line
     if ($line) {
         $profileContent | ForEach-Object { $_.replace( $line, "$importStatement") } | Set-Content $profile

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -17,7 +17,7 @@ function Invoke-SetupAtomicRunner {
 
     if ($artConfig.basehostname.length -gt 15) { Throw "The hostname for this machine (minus the GUID) must be 15 characters or less. Please rename this computer." }
 
-    #create AtomicRunner-Logs directory if it doesn't exist
+    #create AtomicRunner-Logs directories if they don't exist
     New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
     New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore
 

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -1,5 +1,3 @@
-#Requires -RunAsAdministrator
-
 function Invoke-SetupAtomicRunner {
     if($artConfig.basehostname.length -gt 15){ Throw "The hostname for this machine (minus the GUID) must be 15 characters or less. Please rename this computer."}
 

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -107,7 +107,7 @@ function Invoke-SetupAtomicRunner {
 
     $schedule = Get-Schedule
     if ($null -eq $schedule) {
-        Write-Host -ForegroundColor Yellow "There are no tests enabled on the schedule, set the 'Active' column to 'True' for the atomic test that you want to run. The schedule file is found here: $($artConfig.scheduleFile)"
+        Write-Host -ForegroundColor Yellow "There are no tests enabled on the schedule, set the 'Enabled' column to 'True' for the atomic test that you want to run. The schedule file is found here: $($artConfig.scheduleFile)"
         Write-Host -ForegroundColor Yellow "Rerun this setup script after updating the schedule"
     }
     else {

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -1,5 +1,21 @@
 function Invoke-SetupAtomicRunner {
-    if($artConfig.basehostname.length -gt 15){ Throw "The hostname for this machine (minus the GUID) must be 15 characters or less. Please rename this computer."}
+
+    # ensure running with admin privs
+    if ($artConfig.OS -eq "windows") { # auto-elevate on Windows
+        $currentUser = New-Object Security.Principal.WindowsPrincipal $([Security.Principal.WindowsIdentity]::GetCurrent())
+        $testadmin = $currentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+        if ($testadmin -eq $false) {
+            Start-Process powershell.exe -Verb RunAs -ArgumentList ('-noprofile -noexit -file "{0}" -elevated' -f ($myinvocation.MyCommand.Definition))
+            exit $LASTEXITCODE
+        }
+    } else { # linux and macos check - doesn't auto-elevate
+        if((id -u) -ne 0 ){
+            Throw "You must run the Invoke-SetupAtomicRunner script as root"
+            exit
+        }
+    }
+
+    if ($artConfig.basehostname.length -gt 15) { Throw "The hostname for this machine (minus the GUID) must be 15 characters or less. Please rename this computer." }
 
     #create AtomicRunner-Logs directory if it doesn't exist
     New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
@@ -113,3 +129,5 @@ function Invoke-SetupAtomicRunner {
         Invoke-AtomicRunner -GetPrereqs
     }
 }
+
+Invoke-SetupAtomicRunner

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -1,0 +1,116 @@
+function Invoke-SetupAtomicRunner {
+
+    #create AtomicRunner-Logs directory if it doesn't exist
+    New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
+    New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore
+
+    if ($artConfig.gmsaAccount) {
+        $path = Join-Path $env:ProgramFiles "WindowsPowerShell\Modules\RenameRunner\RoleCapabilities"
+        New-Item -ItemType Directory $path -ErrorAction Ignore
+        New-PSSessionConfigurationFile -SessionType RestrictedRemoteServer -GroupManagedServiceAccount $artConfig.gmsaAccount -RoleDefinitions @{ "$($artConfig.user)" = @{ 'RoleCapabilities' = 'RenameRunner' } } -path "$env:Temp\RenameRunner.pssc"
+        New-PSRoleCapabilityFile -VisibleCmdlets @{ 'Name' = 'Rename-Computer'; 'Parameters' = @{ 'Name' = 'NewName'; 'ValidatePattern' = 'ATOMICSOC.*' }, @{ 'Name' = 'Force' }, @{ 'Name' = 'restart' } } -path "$path\RenameRunner.psrc"
+        $null = Register-PSSessionConfiguration -name "RenameRunnerEndpoint" -path "$env:Temp\RenameRunner.pssc" -force
+        Add-LocalGroupMember "administrators" "$($artConfig.gmsaAccount)$" -ErrorAction Ignore
+        # Make sure WinRM is enabled and set to Automic start (not delayed)
+        Set-ItemProperty hklm:\\SYSTEM\CurrentControlSet\Services\WinRM -Name Start -Value 2
+        Set-ItemProperty hklm:\\SYSTEM\CurrentControlSet\Services\WinRM -Name DelayedAutostart -Value 0 # default is delayed start and that is too slow given our 1 minute delay on our kickoff task
+        # this registry key must be set to zero for things to work get-itemproperty hklm:\Software\Policies\Microsoft\Windows\WinRM\Service\
+        $hklmKey = (get-itemproperty hklm:\Software\Policies\Microsoft\Windows\WinRM\Service -name DisableRunAs -ErrorAction ignore).DisableRunAs
+        $hkcuKey = (get-itemproperty hkcu:\Software\Policies\Microsoft\Windows\WinRM\Service -name DisableRunAs -ErrorAction ignore).DisableRunAs
+        if ((1 -eq $hklmKey) -or (1 -eq $hkcuKey)) { Write-Host -ForegroundColor Red "DisableRunAs registry Key will not allow use of the JEA endpoint with a gmsa account" }
+        if ((Get-ItemProperty hklm:\System\CurrentControlSet\Control\Lsa\ -name DisableDomainCreds).DisableDomainCreds) { Write-Host -ForegroundColor Red "Do not allow storage of passwords and credentials for network authentication must be disabled" }
+    }
+
+    if ($artConfig.OS -eq "windows") {
+
+        if (Test-Path $artConfig.credFile) {
+            Write-Host "Credential File $($artConfig.credFile) already exists, not prompting for creation of a new one."
+            $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $artConfig.user, (Get-Content $artConfig.credFile | ConvertTo-SecureString)
+        }
+        else {
+            # create credential file for the user since we aren't using a group managed service account
+            $cred = Get-Credential -UserName $artConfig.user -message "Enter password for $($artConfig.user) in order to create the runner scheduled task"
+            $cred.Password | ConvertFrom-SecureString | Out-File $artConfig.credFile
+    
+        }
+
+        # setup scheduled task that will start the runner after each restart
+        # local security policy --> Local Policies --> Security Options --> Network access: Do not allow storage of passwords and credentials for network authentication must be disabled
+        $taskName = "KickOff-AtomicRunner"
+        Unregister-ScheduledTask $taskName -confirm:$false -ErrorAction Ignore
+        $taskAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-exec bypass -Command Invoke-KickoffAtomicRunner"
+        $taskPrincipal = New-ScheduledTaskPrincipal -UserId $artConfig.user
+        $delays = @(1, 2, 4, 8, 16, 32, 64) # using multiple triggers as a retry mechanism because the built-in retry mechanism doesn't work when the computer renaming causes AD replication delays
+        $triggers = @()
+        foreach ($delay in $delays) {
+            $trigger = New-ScheduledTaskTrigger -AtStartup
+            $trigger.Delay = "PT$delay`M"
+            $triggers += $trigger
+        }
+        $task = New-ScheduledTask -Action $taskAction -Principal $taskPrincipal -Trigger $triggers -Description "A task that runs 1 minute or later after boot to start the atomic test runner script"
+        try {
+            $null = Register-ScheduledTask -TaskName $taskName -InputObject $task -User $artConfig.user -Password $($cred.GetNetworkCredential().password) -ErrorAction Stop
+        }
+        catch {
+            if ($_.CategoryInfo.Category -eq "AuthenticationError") {
+                # remove the credential file if the password didn't work
+                Write-Error "The credentials you entered are incorrect. Please run the setup script again and double check the username and password."
+                Remove-Item $artConfig.credFile
+            }
+            else {
+                Throw $_
+            }
+        }
+    }
+    else {
+        # sets cronjob string using basepath from config.ps1
+        $pwshPath = which pwsh
+        $job = "@reboot root $pwshPath -Command Invoke-KickoffAtomicRunner"
+        $exists = crontab -l | select-string -quiet "KickoffAtomicRunner"
+        #checks if the Kickoff-AtomicRunner job exists. If not appends it to the crontab of current user.
+        if ($null -eq $exists) {
+            $(crontab -u $(whoami) -l; echo "$job") | crontab -u $(whoami) -
+            write-host "setting cronjob"
+        }
+        else {
+            write-host "cronjob already exists"
+        }
+    }
+
+    # Add Import-Module statement to the PowerShell profile
+    $root = Split-Path $PSScriptRoot -Parent
+    $pathToPSD1 = Join-Path $root "Invoke-AtomicRedTeam.psd1"
+    $importStatement = "Import-Module ""$pathToPSD1"" -Force"
+    $profileContent = ""
+    if (Test-Path -Path $profile) { #read in $profile if it exists
+        $profileContent = Get-Content $profile
+    }
+    $line = $profileContent | Select-String ".*import-module.*invoke-atomicredTeam.psd1" | Select-Object -ExpandProperty Line
+    if ($line) {
+        $profileContent | ForEach-Object { $_.replace( $line, "$importStatement") } | Set-Content $profile
+    }
+    else {
+        Add-Content $profile $importStatement
+    }
+    
+    # Install the Posh-SYLOG module if we are configured to use it and it is not already installed
+    if ((-not (Get-InstalledModule "Posh-SYSLOG")) -and [bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
+        write-verbose "Posh-SYSLOG"
+        Install-Module -Name Posh-SYSLOG -Scope CurrentUser -Force
+    }
+
+    # create the CSV schedule of atomics to run if it doesn't exist
+    if (-not (Test-Path $artConfig.scheduleFile)) {
+        Invoke-GenerateNewSchedule
+    }
+
+    $schedule = Get-Schedule
+    if ($null -eq $schedule) {
+        Write-Host -ForegroundColor Yellow "There are no tests enabled on the schedule, set the 'Active' column to 'True' for the atomic test that you want to run. The schedule file is found here: $($artConfig.scheduleFile)"
+        Write-Host -ForegroundColor Yellow "Rerun this setup script after updating the schedule"
+    }
+    else {
+        # Get the prereqs for all of the tests on the schedule
+        Invoke-AtomicRunner -GetPrereqs
+    }
+}

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -109,7 +109,7 @@ function Invoke-SetupAtomicRunner {
     }
     
     # Install the Posh-SYLOG module if we are configured to use it and it is not already installed
-    if ((-not (Get-InstalledModule "Posh-SYSLOG")) -and [bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
+    if ((-not (Get-Module -ListAvailable "Posh-SYSLOG")) -and [bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
         write-verbose "Posh-SYSLOG"
         Install-Module -Name Posh-SYSLOG -Scope CurrentUser -Force
     }

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -129,5 +129,3 @@ function Invoke-SetupAtomicRunner {
         Invoke-AtomicRunner -GetPrereqs
     }
 }
-
-Invoke-SetupAtomicRunner

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -1,6 +1,8 @@
 #Requires -RunAsAdministrator
 
 function Invoke-SetupAtomicRunner {
+    if($artConfig.basehostname.length -gt 15){ Throw "The hostname for this machine (minus the GUID) must be 15 characters or less. Please rename this computer."}
+
     #create AtomicRunner-Logs directory if it doesn't exist
     New-Item -ItemType Directory $artConfig.atomicLogsPath -ErrorAction Ignore
     New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore

--- a/Public/Syslog-ExecutionLogger.psm1
+++ b/Public/Syslog-ExecutionLogger.psm1
@@ -2,7 +2,7 @@ function Start-ExecutionLog($startTime, $logPath, $targetHostname, $targetUser, 
 
 }
 
-function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $stdOut, $stdErr, $isWindows) {
+function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $res, $isWindows) {
     $timeUTC = (Get-Date($startTime).toUniversalTime() -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $timeLocal = (Get-Date($startTime) -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $msg = [PSCustomObject][ordered]@{ 
@@ -16,6 +16,8 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
         "GUID"                   = $testGuid
         "Tag"                    = "atomicrunner"
         "CustomTag"              = $artConfig.CustomTag
+        "ProcessId"              = $res.ProcessId
+        "ExitCode"               = $res.ExitCode
     } 
     
     # send syslog message if a syslog server is defined in Public/config.ps1

--- a/Public/Syslog-ExecutionLogger.psm1
+++ b/Public/Syslog-ExecutionLogger.psm1
@@ -6,19 +6,20 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
     $timeUTC = (Get-Date($startTime).toUniversalTime() -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $timeLocal = (Get-Date($startTime) -uformat "%Y-%m-%dT%H:%M:%SZ").ToString()
     $msg = [PSCustomObject][ordered]@{ 
-        "Execution Time (UTC)"   = $timeUTC;
-        "Execution Time (Local)" = $timeLocal; 
-        "Technique"              = $technique; 
-        "Test Number"            = $testNum; 
-        "Test Name"              = $testName; 
-        "Hostname"               = $targetHostname; 
+        "Execution Time (UTC)"   = $timeUTC
+        "Execution Time (Local)" = $timeLocal 
+        "Technique"              = $technique
+        "Test Number"            = $testNum
+        "Test Name"              = $testName
+        "Hostname"               = $targetHostname
         "Username"               = $targetUser
         "GUID"                   = $testGuid
+        "Tag" = "atomicrunner"
+        "CustomTag" = $artConfig.CustomTag
     } 
     
     # send syslog message if a syslog server is defined in Public/config.ps1
     if([bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort){
-        $msg | Add-Member -Name "Tag" -Type NoteProperty -Value "atomicrunner"
         $jsonMsg = $msg | ConvertTo-Json
         Send-SyslogMessage -Server $artConfig.syslogServer -Port $artConfig.syslogPort -Message $jsonMsg -Severity "Informational" -Facility "daemon"
     }

--- a/Public/Syslog-ExecutionLogger.psm1
+++ b/Public/Syslog-ExecutionLogger.psm1
@@ -14,12 +14,12 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
         "Hostname"               = $targetHostname
         "Username"               = $targetUser
         "GUID"                   = $testGuid
-        "Tag" = "atomicrunner"
-        "CustomTag" = $artConfig.CustomTag
+        "Tag"                    = "atomicrunner"
+        "CustomTag"              = $artConfig.CustomTag
     } 
     
     # send syslog message if a syslog server is defined in Public/config.ps1
-    if([bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort){
+    if ([bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
         $jsonMsg = $msg | ConvertTo-Json
         Send-SyslogMessage -Server $artConfig.syslogServer -Port $artConfig.syslogPort -Message $jsonMsg -Severity "Informational" -Facility "daemon"
     }

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -2,36 +2,39 @@
 $artConfig = [PSCustomObject]@{
 
   # [optional] These three configs are calculated programatically, you probably don't need to change them
-  basehostname               = $((hostname).split("-")[0]);
-  OS                         = $( if ($IsLinux) { "linux" } elseif ($IsMacOS) { "macos" } else { "windows" });
+  basehostname               = $((hostname).split("-")[0])
+  OS                         = $( if ($IsLinux) { "linux" } elseif ($IsMacOS) { "macos" } else { "windows" })
 
   # [optional(if using default install paths)] Paths to your Atomic Red Team "atomics" folder and your "invoke-atomicredteam" folder
-  PathToInvokeFolder         = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })  "/AtomicRedTeam/invoke-atomicredteam"; # this is the default install path so you probably don't need to change this
-  PathToPublicAtomicsFolder  = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })  "AtomicRedTeam/atomics"; # this is the default install path so you probably don't need to change this
-  PathToPrivateAtomicsFolder = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })   "PrivateAtomics/atomics"; # if you aren't providing your own private atomics that are custom written by you, just leave this as is
+  PathToInvokeFolder         = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })  "/AtomicRedTeam/invoke-atomicredteam" # this is the default install path so you probably don't need to change this
+  PathToPublicAtomicsFolder  = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })  "AtomicRedTeam/atomics" # this is the default install path so you probably don't need to change this
+  PathToPrivateAtomicsFolder = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })   "PrivateAtomics/atomics" # if you aren't providing your own private atomics that are custom written by you, just leave this as is
 
   # [ Optional ] The user that will be running each atomic test
-  user                       = $( if ($IsLinux -or $IsMacOS) { $env:USER } else { "$env:USERDOMAIN\$env:USERNAME" }); # example "corp\atomicrunner"
+  user                       = $( if ($IsLinux -or $IsMacOS) { $env:USER } else { "$env:USERDOMAIN\$env:USERNAME" }) # example "corp\atomicrunner"
 
   # [optional] the path where you want the folder created that houses the logs and the runner schedule. Defaults to users home directory
-  basePath                   = $( if (!$IsLinux -and !$IsMacOS) { $env:USERPROFILE } else { $env:HOME }); # example "C:\Users\atomicrunner"
+  basePath                   = $( if (!$IsLinux -and !$IsMacOS) { $env:USERPROFILE } else { $env:HOME }) # example "C:\Users\atomicrunner"
 
   # [optional]
-  scheduleTimeSpan           = New-TimeSpan -Days 7; # the time in which all tests on the schedule should complete
+  scheduleTimeSpan           = New-TimeSpan -Days 7 # the time in which all tests on the schedule should complete
 
 
   # [optional] If you need to use a group managed service account in order to rename the computer, enter it here
-  gmsaAccount                = $null;
+  gmsaAccount                = $null
 
   # [optional] Syslog configuration, default execution logs will be sent to this server:port
-  syslogServer               = ''; # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
-  syslogPort                 = 514;
+  syslogServer               = '' # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
+  syslogPort                 = 514
  
   verbose                    = $true; # set to true for more log output
 
   # [optional] logfile filename configs
   logFolder                  = "AtomicRunner-Logs"
   timeLocal                  = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
+
+  # [optional] don't rename and restart the computer when executing the atomic runner schedule
+  skipRenameAndRestart       = $false
 
   # amsi bypass script block (applies to Windows only)
   absb                       = $null

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -1,7 +1,7 @@
 
 $artConfig = [PSCustomObject]@{
 
-  # [optional] These three configs are calculated programatically, you probably don't need to change them
+  # [optional] These two configs are calculated programatically, you probably don't need to change them
   basehostname               = $((hostname).split("-")[0])
   OS                         = $( if ($IsLinux) { "linux" } elseif ($IsMacOS) { "macos" } else { "windows" })
 

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -18,7 +18,7 @@ $artConfig = [PSCustomObject]@{
 
   # [optional]
   scheduleTimeSpan           = New-TimeSpan -Days 7 # the time in which all tests on the schedule should complete
-
+  kickOffDelay               = New-TimeSpan -Minutes 0 # an additional delay before Invoke-KickoffAtomicRunner calls Invoke-AtomicRunner
 
   # [optional] If you need to use a group managed service account in order to rename the computer, enter it here
   gmsaAccount                = $null

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -2,43 +2,40 @@
 $artConfig = [PSCustomObject]@{
 
   # [optional] These three configs are calculated programatically, you probably don't need to change them
-  basehostname       = $((hostname).split("-")[0]);
-  universalHomeDrive = $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" });
-  OS                 = $( if ($IsLinux) { "linux" } elseif ($IsMacOS) { "macos" } else { "windows" });
+  basehostname               = $((hostname).split("-")[0]);
+  OS                         = $( if ($IsLinux) { "linux" } elseif ($IsMacOS) { "macos" } else { "windows" });
+
+  # [optional(if using default install paths)] Paths to your Atomic Red Team "atomics" folder and your "invoke-atomicredteam" folder
+  PathToInvokeFolder         = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })  "/AtomicRedTeam/invoke-atomicredteam"; # this is the default install path so you probably don't need to change this
+  PathToPublicAtomicsFolder  = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })  "AtomicRedTeam/atomics"; # this is the default install path so you probably don't need to change this
+  PathToPrivateAtomicsFolder = Join-Path $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" })   "PrivateAtomics/atomics"; # if you aren't providing your own private atomics that are custom written by you, just leave this as is
 
   # [ Optional ] The user that will be running each atomic test
-  user               = $( if ($IsLinux -or $IsMacOS) { $env:USER } else { "$env:USERDOMAIN\$env:USERNAME" }); # example "corp\atomicrunner"
+  user                       = $( if ($IsLinux -or $IsMacOS) { $env:USER } else { "$env:USERDOMAIN\$env:USERNAME" }); # example "corp\atomicrunner"
 
   # [optional] the path where you want the folder created that houses the logs and the runner schedule. Defaults to users home directory
-  basePath           = $( if (!$IsLinux -and !$IsMacOS) { $env:USERPROFILE } else { $env:HOME }); # example "C:\Users\atomicrunner"
+  basePath                   = $( if (!$IsLinux -and !$IsMacOS) { $env:USERPROFILE } else { $env:HOME }); # example "C:\Users\atomicrunner"
 
   # [optional]
-  scheduleTimeSpan   = New-TimeSpan -Days 7; # the time in which all tests on the schedule should complete
+  scheduleTimeSpan           = New-TimeSpan -Days 7; # the time in which all tests on the schedule should complete
 
 
   # [optional] If you need to use a group managed service account in order to rename the computer, enter it here
-  gmsaAccount        = $null;
+  gmsaAccount                = $null;
 
   # [optional] Syslog configuration, default execution logs will be sent to this server:port
-  syslogServer       = ''; # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
-  syslogPort         = 514;
+  syslogServer               = ''; # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
+  syslogPort                 = 514;
  
-  verbose            = $true; # set to true for more log output
+  verbose                    = $true; # set to true for more log output
 
   # [optional] logfile filename configs
-  logFolder          = "AtomicRunner-Logs"
-  timeLocal          = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
+  logFolder                  = "AtomicRunner-Logs"
+  timeLocal                  = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
 
   # amsi bypass script block (applies to Windows only)
-  absb               = $null
+  absb                       = $null
 
-}
-
-$artConfig | Add-Member -NotePropertyMembers @{
-  # [optional(if using default install paths)] Paths to your Atomic Red Team "atomics" folder and your "invoke-atomicredteam" folder
-  PathToInvokeFolder         = Join-Path $artConfig.universalHomeDrive   "/AtomicRedTeam/invoke-atomicredteam"; # this is the default install path so you probably don't need to change this
-  PathToPublicAtomicsFolder  = Join-Path $artConfig.universalHomeDrive  "AtomicRedTeam/atomics"; # this is the default install path so you probably don't need to change this
-  PathToPrivateAtomicsFolder = Join-Path $artConfig.universalHomeDrive  "PrivateAtomics/atomics"; # if you aren't providing your own private atomics that are custom written by you, just leave this as is
 }
 
 # If you create a file called privateConfig.ps1 in the same directory as you installed Invoke-AtomicRedTeam you can overwrite any of these settings with your custom values

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -33,9 +33,6 @@ $artConfig = [PSCustomObject]@{
   logFolder                  = "AtomicRunner-Logs"
   timeLocal                  = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
 
-  # [optional] don't rename and restart the computer when executing the atomic runner schedule
-  skipRenameAndRestart       = $false
-
   # amsi bypass script block (applies to Windows only)
   absb                       = $null
 

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -1,0 +1,114 @@
+
+$artConfig = [PSCustomObject]@{
+
+  # [optional] These three configs are calculated programatically, you probably don't need to change them
+  basehostname       = $((hostname).split("-")[0]);
+  universalHomeDrive = $( if ($IsLinux -or $IsMacOS) { "~" } else { "C:" });
+  OS                 = $( if ($IsLinux) { "linux" } elseif ($IsMacOS) { "macos" } else { "windows" });
+
+  # [ Optional ] The user that will be running each atomic test
+  user               = $( if ($IsLinux -or $IsMacOS) { $env:USER } else { "$env:USERDOMAIN\$env:USERNAME" }); # example "corp\atomicrunner"
+
+  # [optional] the path where you want the folder created that houses the logs and the runner schedule. Defaults to users home directory
+  basePath           = $( if (!$IsLinux -and !$IsMacOS) { $env:USERPROFILE } else { $env:HOME }); # example "C:\Users\atomicrunner"
+
+  # [optional]
+  scheduleTimeSpan   = New-TimeSpan -Days 7; # the time in which all tests on the schedule should complete
+
+
+  # [optional] If you need to use a group managed service account in order to rename the computer, enter it here
+  gmsaAccount        = $null;
+
+  # [optional] Syslog configuration, default execution logs will be sent to this server:port
+  syslogServer       = ''; # set to empty string '' if you don't want to log atomic execution details to a syslog server (don't includle http(s):\\)
+  syslogPort         = 514;
+ 
+  verbose            = $true; # set to true for more log output
+
+  # [optional] logfile filename configs
+  logFolder          = "AtomicRunner-Logs"
+  timeLocal          = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
+
+  # amsi bypass script block (applies to Windows only)
+  absb               = $null
+
+}
+
+$artConfig | Add-Member -NotePropertyMembers @{
+  # [optional(if using default install paths)] Paths to your Atomic Red Team "atomics" folder and your "invoke-atomicredteam" folder
+  PathToInvokeFolder         = Join-Path $artConfig.universalHomeDrive   "/AtomicRedTeam/invoke-atomicredteam"; # this is the default install path so you probably don't need to change this
+  PathToPublicAtomicsFolder  = Join-Path $artConfig.universalHomeDrive  "AtomicRedTeam/atomics"; # this is the default install path so you probably don't need to change this
+  PathToPrivateAtomicsFolder = Join-Path $artConfig.universalHomeDrive  "PrivateAtomics/atomics"; # if you aren't providing your own private atomics that are custom written by you, just leave this as is
+}
+
+# If you create a file called privateConfig.ps1 in the same directory as you installed Invoke-AtomicRedTeam you can overwrite any of these settings with your custom values
+$root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$pathToPrivateConfig = Join-Path $root "privateConfig.ps1"
+if (Test-Path ($pathToPrivateConfig)) {
+  & ($pathToPrivateConfig)
+}
+else {
+  Write-Host -ForegroundColor Yellow "No private config file found at $pathToPrivateConfig"
+}
+
+#####################################################################################
+# All of the configs below are calculated using the script block in the "Value" field.
+# This way, when you change the 'basePath' everything else is updated.
+# You should probably leave all of the stuff below alone.
+#####################################################################################
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "runnerFolder"
+  Value       = { Join-Path $artConfig.basePath "AtomicRunner" }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "atomicLogsPath"
+  Value       = { Join-Path $artConfig.basePath $artConfig.logFolder }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "scheduleFile"
+  Value       = { Join-Path $artConfig.runnerFolder "AtomicRunnerSchedule.csv" }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "credFile"
+  Value       = { Join-Path $artConfig.runnerFolder "psc_$($artConfig.basehostname).txt" }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "execLogPath"
+  Value       = { Join-Path $artConfig.atomicLogsPath "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv" }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "stopFile"
+  Value       = { Join-Path $artConfig.runnerFolder "stop.txt" }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $artConfig
+  Name        = "logFile"
+  Value       = { Join-Path $artConfig.atomicLogsPath "log-$($artConfig.basehostname).txt" }
+}
+Add-Member @scriptParam

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -44,9 +44,6 @@ $pathToPrivateConfig = Join-Path $root "privateConfig.ps1"
 if (Test-Path ($pathToPrivateConfig)) {
   & ($pathToPrivateConfig)
 }
-else {
-  Write-Host -ForegroundColor Yellow "No private config file found at $pathToPrivateConfig"
-}
 
 #####################################################################################
 # All of the configs below are calculated using the script block in the "Value" field.


### PR DESCRIPTION
Add the ability to read a list of atomics from a CSV file and execute them as a single emulation or continuously around the clock. This code adds a new Invoke-AtomicRunner function but doesn't change how Invoke-AtomicRedTeam functions using `Invoke-AtomicTest`.

Full documentation included on the wiki page [here](https://github.com/redcanaryco/invoke-atomicredteam/wiki/Adversary-Emulation) for basic usage and [here](https://github.com/redcanaryco/invoke-atomicredteam/wiki/Continuous-Atomic-Testing) for continuous, around the clock usage.

This Pull Request also includes a new SysLog logger option as described [here](https://github.com/redcanaryco/invoke-atomicredteam/wiki/Execution-Logging#syslog-logger)

It also adds the process ID and process exit code to the execution log to aid in correlating with your telemetry and in determining if an atomic ran successfully.

🥇  Thank you to all of the authors of this functionality (@clr2of8, @dwhite9, @Andras32, @bagelsrgood4me, and @ge0var)