### PR TITLE
Handle case that remote session is null, avoid edge case where process hangs

### DIFF
--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -56,9 +56,7 @@ function Invoke-Process {
                     $isTimeout = $true
                     Invoke-KillProcessTree $process.id
                     Write-Host -ForegroundColor Red "Process Timed out after $TimeoutSeconds seconds, use '-TimeoutSeconds' to specify a different timeout"
-                } else {
-                    $process.WaitForExit()
-                }
+                } 
                 $process.CancelOutputRead()
                 $process.CancelErrorRead()
 

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -519,4 +519,3 @@ function Invoke-AtomicTest {
     } # End of PROCESS block
     END { } # Intentionally left blank and can be removed
 }
-Invoke-AtomicTest T1016 -Session $null


### PR DESCRIPTION
Removed the indefinite processwait and handle the case when the remote session is null so that the test doesn't default to runner against localhost.