### PR TITLE
add import of dependent code

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -1,3 +1,5 @@
+. "$PSScriptRoot\Invoke-RunnerScheduleMethods.ps1"
+
 function Invoke-AtomicRunner {
     [CmdletBinding(
         SupportsShouldProcess = $true,


### PR DESCRIPTION
this solves an issue where the "Get-Schedule" function was not available on first-time imports of Invoke-AtomicRedTeam