### PR TITLE
Added code to add execution privilege to the privateConfig.ps1 file on Linux and MacOS.

### DIFF
--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -45,6 +45,9 @@ $artConfig = [PSCustomObject]@{
 $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $pathToPrivateConfig = Join-Path $root "privateConfig.ps1"
 if (Test-Path ($pathToPrivateConfig)) {
+  if ($IsLinux -or $IsMacOS) {
+    chmod +x $pathToPrivateConfig
+  }
   & ($pathToPrivateConfig)
 }
 


### PR DESCRIPTION
On Linux the privateConfig.ps1 file must have execution rights in order to be loaded by the PowerShell profile. This code checks the OS, and adds execution privileges via chmod.

Tested on:
Ubuntu 22.04.2 LTS
macOS 13.3.1