### PR TITLE
Update Install-AtomicsFolder to support powershell 7.2+ 

### DIFF
--- a/install-atomicsfolder.ps1
+++ b/install-atomicsfolder.ps1
@@ -86,7 +86,8 @@ function Install-AtomicsFolder {
                 $ms = New-Object IO.MemoryStream
                 [Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12)
 
-                $webClient = New-Object ExtendedWebClient; 
+                $webClient = New-Object HttpClient;
+		$webClient.Timeout = TimeSpan.FromMinutes(3);
                 $webClient.OpenRead($url).copyto($ms)
                 $Zip = New-Object System.IO.Compression.ZipArchive($ms)
 
@@ -139,29 +140,4 @@ function Install-AtomicsFolder {
         Write-Host -ForegroundColor Red "Installation of the AtomicsFolder Failed."
         Write-Host $_.Exception.Message`n
     }
-}
-
-# ExtendedWebClient from https://koz.tv/setup-webclient-timeout-in-powershell/
-$Source = @" 
-using System.Net;
-
-public class ExtendedWebClient : WebClient { 
-    public int Timeout;
-
-    protected override WebRequest GetWebRequest(System.Uri address) { 
-        WebRequest request = base.GetWebRequest(address); 
-        if (request != null) {
-            request.Timeout = Timeout;
-        }
-        return request;
-    }
-
-    public ExtendedWebClient() {
-        Timeout = 180000; // 3 minutes
-    } 
-} 
-"@;
-
-if (-not ([System.Management.Automation.PSTypeName]'ExtendedWebClient').Type) {
-    Add-Type -TypeDefinition $Source -Language CSharp
 }


### PR DESCRIPTION
Powershell 7.2 and newer has deprecated WebClient (along with WebRequest, HttpWebRequest, and ServicePoint). This PR replaces the ExtendedWebClient object with HttpClient and uses the .Timeout option to specify the same 3 minute timeout as previously defined in the custom ExtendedWebClient class. 

Errors as shown on various Linux distributions using pwsh 7.2 or 7.3
```
VERBOSE: Installing Atomics Folder
Add-Type:
Line |
 166 |      Add-Type -TypeDefinition $Source -Language CSharp
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | (14,5): error SYSLIB0014: 'WebClient.WebClient()' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.'
    public ExtendedWebClient() {
    ^
Installation of AtomicRedTeam Failed.
Cannot add type. Compilation errors occurred.
```

I have tested this against pwsh 7.3 on Ubuntu 22.04 and have had no issues completing the installation of the atomics folder now. 