### PR TITLE
skip renaming computer if name is the same

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -95,7 +95,7 @@ function Invoke-AtomicRunner {
             }
             else {
                 if ($debug) { LogRunnerMsg "Debug: pretending to rename the computer to $newHostName"; exit }
-                if (-not $shouldRename) { Restart-Computer -Force -Wait }
+                if (-not $shouldRename) { Restart-Computer -Force }
                 if ($artConfig.gmsaAccount) {
                     $retry = $true; $count = 0
                     while ($retry) {


### PR DESCRIPTION
This change supports having only 1 atomic test enabled for the atomic runner. Previously, if only one atomic test was enabled the attempt to rename the computer generated an error resulting in the computer not restarting.