### PR TITLE
add timestamp to logfile name

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -157,7 +157,10 @@ function Invoke-AtomicTest {
             else {
                 Write-Host -Fore Yellow "Logger not found: ", $LoggingModule
             }
-       
+
+            # Change the defult logFile extension from csv to json if using the Attire-ExecutionLogger
+            if ($LoggingModule -eq "Attire-ExecutionLogger") { $ExecutionLogPath = $ExecutionLogPath.Replace("Invoke-AtomicTest-ExecutionLog.csv", "Invoke-AtomicTest-ExecutionLog-timestamp.json") }
+            $ExecutionLogPath = $ExecutionLogPath.Replace("timestamp", $(Get-Date -UFormat %s))
 
             if (Get-Command "$LoggingModule\Start-ExecutionLog" -erroraction silentlycontinue) {
                 if (Get-Command "$LoggingModule\Write-ExecutionLog" -erroraction silentlycontinue) {

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -158,7 +158,7 @@ function Invoke-AtomicTest {
                 Write-Host -Fore Yellow "Logger not found: ", $LoggingModule
             }
 
-            # Change the defult logFile extension from csv to json if using the Attire-ExecutionLogger
+            # Change the defult logFile extension from csv to json and add a timestamp if using the Attire-ExecutionLogger
             if ($LoggingModule -eq "Attire-ExecutionLogger") { $ExecutionLogPath = $ExecutionLogPath.Replace("Invoke-AtomicTest-ExecutionLog.csv", "Invoke-AtomicTest-ExecutionLog-timestamp.json") }
             $ExecutionLogPath = $ExecutionLogPath.Replace("timestamp", $(Get-Date -UFormat %s))
 


### PR DESCRIPTION
If using the Attire-Execution logger, change the default ExecutionLogPath extension to json. Also add a `timestamp` placeholder. Any ExecutionLogPath with a `timestamp` place holder will be replaced by the current time stamp. This is especially helpful when using the Attire logger since it overwrites log files instead of appending to them unless a different ExecutionLogPath is specified.