### PR TITLE
Tab Completion

### DIFF
--- a/Public/Get-AtomicTechnique.ps1
+++ b/Public/Get-AtomicTechnique.ps1
@@ -498,3 +498,22 @@ filter Get-AtomicTechnique {
         $AtomicInstance
     }
 }
+
+
+# Tab completion for Atomic Tests
+function Get-TechniqueNumbers {
+    $PathToAtomicsFolder = if ($IsLinux -or $IsMacOS) { $Env:HOME + "/AtomicRedTeam/atomics" } else { $env:HOMEDRIVE + "\AtomicRedTeam\atomics" }
+    $techniqueNumbers = Get-ChildItem $PathToAtomicsFolder -Directory |
+                       ForEach-Object { $_.BaseName }
+
+    return $techniqueNumbers
+}
+
+Register-ArgumentCompleter -CommandName 'Invoke-AtomicTest' -ParameterName 'AtomicTechnique' -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    Get-TechniqueNumbers | Where-Object { $_ -like "$wordToComplete*" } |
+    ForEach-Object {
+        New-Object System.Management.Automation.CompletionResult $_, $_, 'ParameterValue', "Technique number $_"
+    }
+}


### PR DESCRIPTION
The following adds the ability to use tab completion when finding a Technique to run. 

It's as simple as :

Invoke-AtomicTest T<tab><tab> to autocomplete your Technique number. 

An example may be - you remember the technique is T12 something, well now you can cycle through the T12's:

Invoke-AtomicTest T12<tab> and keep tabbing until you get to T1218. 


https://github.com/redcanaryco/invoke-atomicredteam/assets/5632822/32353707-2651-4a0e-96ec-70dfbe918a1a

Note:
If invoke-atomictest is already imported, you will need to re-import the module in order to get the tab completion. Enjoy!