### PR TITLE
add option to supress printing of atomicsfolder to screen

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -31,7 +31,7 @@ function Invoke-AtomicRunner {
         $LoggingModule,
 
         [Parameter(Mandatory = $false)]
-        $listOfAtomics,
+        $ListOfAtomics,
 
         [Parameter(Mandatory = $false, ValueFromRemainingArguments = $true)]
         $OtherArgs
@@ -61,10 +61,10 @@ function Invoke-AtomicRunner {
             $sc = $tr.AtomicsFolder
             #Run the Test based on if scheduleContext is 'private' or 'public'
             if (($sc -eq 'public') -or ($null -eq $sc)) {
-                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPublicAtomicsFolder @htvars -Cleanup:$Cleanup
+                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPublicAtomicsFolder @htvars -Cleanup:$Cleanup -supressPathToAtomicsFolder
             }
             elseif ($sc -eq 'private') {
-                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPrivateAtomicsFolder @htvars -Cleanup:$Cleanup
+                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPrivateAtomicsFolder @htvars -Cleanup:$Cleanup -supressPathToAtomicsFolder
             }
         }
 

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -111,7 +111,12 @@ function Invoke-AtomicTest {
         [Parameter(Mandatory = $false,
             ParameterSetName = 'technique')]
         [String]
-        $LoggingModule
+        $LoggingModule,
+
+        [Parameter(Mandatory = $false,
+            ParameterSetName = 'technique')]
+        [switch]
+        $SupressPathToAtomicsFolder = $false
 
     )
     BEGIN { } # Intentionally left blank and can be removed
@@ -119,7 +124,7 @@ function Invoke-AtomicTest {
         $PathToAtomicsFolder = (Resolve-Path $PathToAtomicsFolder).Path
         
         Write-Verbose -Message 'Attempting to run Atomic Techniques'
-        Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n"
+        if(-not $supressPathToAtomicsFolder) { Write-Host -ForegroundColor Cyan "PathToAtomicsFolder = $PathToAtomicsFolder`n" }
         
         $executionPlatform, $isElevated, $tmpDir, $executionHostname, $executionUser = Get-TargetInfo $Session
         $PathToPayloads = if ($Session) { "$tmpDir`AtomicRedTeam" }  else { $PathToAtomicsFolder }


### PR DESCRIPTION
This option is nice when Invoke-AtomicRunner is used. Otherwise the path to atomics folder is printed to the screen once for every atomic on the list/schedule.