### PR TITLE
use relative paths for nested modules

### DIFF
--- a/Invoke-AtomicRedTeam.psd1
+++ b/Invoke-AtomicRedTeam.psd1
@@ -54,10 +54,10 @@
     VariablesToExport = '*'
 
     NestedModules = @(
-        "$PSScriptRoot\Public\Default-ExecutionLogger.psm1",
-        "$PSScriptRoot\Public\Attire-ExecutionLogger.psm1",
-        "$PSScriptRoot\Public\Syslog-ExecutionLogger.psm1",
-        "$PSScriptRoot\Public\WinEvent-ExecutionLogger.psm1"
+        "Public\Default-ExecutionLogger.psm1",
+        "Public\Attire-ExecutionLogger.psm1",
+        "Public\Syslog-ExecutionLogger.psm1",
+        "Public\WinEvent-ExecutionLogger.psm1"
         )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.


### PR DESCRIPTION
Using relative file path for nested modules specified in the module manifest to avoid the following where where publishing the module to the PowerShell Gallery. `Unexpected element encountered`

![image](https://github.com/redcanaryco/invoke-atomicredteam/assets/22311332/d0d6f4ab-28c6-4ff4-a992-bc073e3d8d01)
