### PR TITLE
clarify which expand-archive function to use

### DIFF
--- a/install-atomicredteam.ps1
+++ b/install-atomicredteam.ps1
@@ -83,7 +83,7 @@ function Install-AtomicRedTeam {
 
             write-verbose "Extracting ART to $InstallPath"
             $zipDest = Join-Path "$DownloadPath" "tmp"
-            expand-archive -LiteralPath $path -DestinationPath "$zipDest" -Force:$Force
+            Microsoft.PowerShell.Archive\Expand-Archive -LiteralPath $path -DestinationPath "$zipDest" -Force:$Force
             $iartFolderUnzipped = Join-Path $zipDest "invoke-atomicredteam-$Branch"
             Move-Item $iartFolderUnzipped $InstallPathwIart
             Remove-Item $zipDest -Recurse -Force

--- a/install-atomicsfolder.ps1
+++ b/install-atomicsfolder.ps1
@@ -121,7 +121,7 @@ function Install-AtomicsFolder {
 
                 write-verbose "Extracting ART to $InstallPath"
                 $zipDest = Join-Path "$DownloadPath" "tmp"
-                expand-archive -LiteralPath $path -DestinationPath "$zipDest" -Force:$Force
+                Microsoft.PowerShell.Archive\Expand-Archive -LiteralPath $path -DestinationPath "$zipDest" -Force:$Force
                 $atomicsFolderUnzipped = Join-Path (Join-Path $zipDest "atomic-red-team-$Branch") "atomics"
                 Move-Item $atomicsFolderUnzipped $InstallPath
                 Remove-Item $zipDest -Recurse -Force


### PR DESCRIPTION
fixing issue #119 with the solution described [here](https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/52)

"on some systems Microsoft.PowerShell.Archive is used and DestinationPath works, but in other systems Pscx module is used and OutputPath works."