### PR TITLE
fix test number calculation

### DIFF
--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -362,12 +362,13 @@ function Invoke-AtomicTest {
                 Write-Debug -Message "Gathering tests for Technique $technique"
 
                 $testCount = 0
-                $order = 1
+                $order = 0
                 foreach ($test in $technique.atomic_tests) {
 
                     Write-Verbose -Message 'Determining tests for target platform'
 
                     $testCount++
+                    $order++
                     
                     if (($ShowDetails -or $ShowDetailsBrief) -and -not $anyOS) {
                         if ( -not $(Platform-IncludesCloud) -and -Not $test.supported_platforms.Contains($executionPlatform) ) {
@@ -486,7 +487,6 @@ function Invoke-AtomicTest {
                         $stopTime = Get-Date
                         if ($isLoggingModuleSet) {
                             &"$LoggingModule\Write-ExecutionLog" $startTime $stopTime $AT $order $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res (-Not($IsLinux -or $IsMacOS))
-                            $order++
                         }
                         Write-KeyValue "Done executing test: " $testId
                     }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -362,13 +362,11 @@ function Invoke-AtomicTest {
                 Write-Debug -Message "Gathering tests for Technique $technique"
 
                 $testCount = 0
-                $order = 0
                 foreach ($test in $technique.atomic_tests) {
 
                     Write-Verbose -Message 'Determining tests for target platform'
 
                     $testCount++
-                    $order++
                     
                     if (($ShowDetails -or $ShowDetailsBrief) -and -not $anyOS) {
                         if ( -not $(Platform-IncludesCloud) -and -Not $test.supported_platforms.Contains($executionPlatform) ) {
@@ -486,7 +484,7 @@ function Invoke-AtomicTest {
                         $res = Invoke-ExecuteCommand $final_command $test.executor.name $executionPlatform $TimeoutSeconds $session -Interactive:$Interactive
                         $stopTime = Get-Date
                         if ($isLoggingModuleSet) {
-                            &"$LoggingModule\Write-ExecutionLog" $startTime $stopTime $AT $order $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res (-Not($IsLinux -or $IsMacOS))
+                            &"$LoggingModule\Write-ExecutionLog" $startTime $stopTime $AT $testCount $test.name $test.auto_generated_guid $test.executor.name $test.description $final_command $ExecutionLogPath $executionHostname $executionUser $res (-Not($IsLinux -or $IsMacOS))
                         }
                         Write-KeyValue "Done executing test: " $testId
                     }


### PR DESCRIPTION
Execution logs were recording the wrong atomic test number and this fixes it