### PR TITLE
start winrm service

### DIFF
--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -22,6 +22,7 @@ function Invoke-SetupAtomicRunner {
     New-Item -ItemType Directory $artConfig.runnerFolder -ErrorAction Ignore
 
     if ($artConfig.gmsaAccount) {
+        Start-Service WinRM
         $path = Join-Path $env:ProgramFiles "WindowsPowerShell\Modules\RenameRunner\RoleCapabilities"
         New-Item -ItemType Directory $path -ErrorAction Ignore
         New-PSSessionConfigurationFile -SessionType RestrictedRemoteServer -GroupManagedServiceAccount $artConfig.gmsaAccount -RoleDefinitions @{ "$($artConfig.user)" = @{ 'RoleCapabilities' = 'RenameRunner' } } -path "$env:Temp\RenameRunner.pssc"


### PR DESCRIPTION
WinRM service must be running when using Atomic Runner functionality with a gMSA account to do the computer renaming.