### PR TITLE
add atomic runner hooks

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -174,7 +174,7 @@ function Invoke-AtomicRunner {
             }
             return
         }
-   
+
         # exit if file stop.txt is found
         If (Test-Path $artConfig.stopFile) {
             LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -174,7 +174,7 @@ function Invoke-AtomicRunner {
             }
             return
         }
-        
+   
         # exit if file stop.txt is found
         If (Test-Path $artConfig.stopFile) {
             LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -192,11 +192,15 @@ function Invoke-AtomicRunner {
             }
 
             if ($null -ne $tr) {
+                if (Get-Command 'Invoke-AtomicRunnerPreAtomicHook' -errorAction SilentlyContinue) { Invoke-AtomicRunnerPreAtomicHook }
                 Invoke-AtomicTestFromScheduleRow $tr
+                if (Get-Command 'Invoke-AtomicRunnerPostAtomicHook' -errorAction SilentlyContinue) { Invoke-AtomicRunnerPostAtomicHook }
                 Write-Host -Fore cyan "Sleeping for $SleepTillCleanup seconds before cleaning up"; Start-Sleep -Seconds $SleepTillCleanup
                 
                 # Cleanup after running test
+                if (Get-Command 'Invoke-AtomicRunnerPreAtomicCleanupHook' -errorAction SilentlyContinue) { Invoke-AtomicRunnerPreAtomicCleanupHook }
                 Invoke-AtomicTestFromScheduleRow $tr $true
+                if (Get-Command 'Invoke-AtomicRunnerPostAtomicCleanupHook' -errorAction SilentlyContinue) { Invoke-AtomicRunnerPostAtomicCleanupHook }
             }
             else {
                 LogRunnerMsg "Could not find Test: $guid in schedule. Please update schedule to run this test."

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -1,4 +1,5 @@
 . "$PSScriptRoot\Invoke-RunnerScheduleMethods.ps1"
+
 function Invoke-AtomicRunner {
     [CmdletBinding(
         SupportsShouldProcess = $true,
@@ -173,6 +174,7 @@ function Invoke-AtomicRunner {
             }
             return
         }
+        
         # exit if file stop.txt is found
         If (Test-Path $artConfig.stopFile) {
             LogRunnerMsg "exiting script because $($artConfig.stopFile) does exist"


### PR DESCRIPTION
Users can define 4 different functions that will be called (if they exist) before/after atomic execution or before/after atomic test cleanup commands (only applies when calling Invoke-AtomicRunner):

1. Invoke-AtomicRunnerPreAtomicHook
2. Invoke-AtomicRunnerPostAtomicHook
3. Invoke-AtomicRunnerPreAtomicCleanupHook
4. Invoke-AtomicRunnerPostAtomicCleanupHook