### PR TITLE
add rename retries

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -117,6 +117,13 @@ function Invoke-AtomicRunner {
                 }
                 Start-Sleep -seconds 30
                 LogRunnerMsg "uh oh, still haven't restarted - should never get to here"
+                $retry = $true; $count = 0
+                while ($retry) {
+                    Restart-Computer -Force
+                    Start-Sleep 300; $count = $count + 1
+                    LogRunnerMsg "Rename retry $count"
+                    if ($count -gt 60) { $retry = $false }
+                }
                 exit
             }
             


### PR DESCRIPTION
In some situations for Windows Atomic Runners, the computer isn't restarting as part of the rename command causing the computer to inaccessible via RDP with domain credentials because the machine has lost its domain trust relationship (until it is rebooted). We are handling that case by adding some retries to the reboot.