### PR TITLE
Option to pause runner between atomics & invoke-commandfix

### DIFF
--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -16,7 +16,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $T
                     $finalCommand = $finalCommand -replace "[\\](?!;)", "`\$&"
                     $finalCommand = $finalCommand -replace "[`"]", "`\$&"
                     $execCommand = $finalCommand -replace "(?<!;)\n", "; "
-                    $arguments = "$execPrefix $execCommand"
+                    $arguments = "$execPrefix `"$execCommand`""
 
             }
         }

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -16,7 +16,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $T
                     $finalCommand = $finalCommand -replace "[`"]", "`\$&"
                     $execCommand = $finalCommand -replace "(?<!;)\n", "; "
             }
-            $arguments = "$execPrefix `"$execCommand`""
+            $arguments = $execPrefix,"$execCommand"
         }
         elseif ($executor -eq "powershell") {
             $execCommand = $finalCommand -replace "`"", "`\`"`""
@@ -46,6 +46,8 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $T
                     IsTimeOut = $false
                 }
         }
+
+        # Write-Host -ForegroundColor Magenta "$execExe $arguments"
         if ($session) {
             $scriptParentPath = Split-Path $import -Parent
             $fp = Join-Path $scriptParentPath "Invoke-Process.ps1"

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -10,13 +10,15 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $T
                     $execPrefix = "/c"; 
                     $execExe = "cmd.exe"; 
                     $execCommand = $finalCommand -replace "`n", " & " 
-            }
+                    $arguments = $execPrefix,"$execCommand"
+                }
             else {
                     $finalCommand = $finalCommand -replace "[\\](?!;)", "`\$&"
                     $finalCommand = $finalCommand -replace "[`"]", "`\$&"
                     $execCommand = $finalCommand -replace "(?<!;)\n", "; "
+                    $arguments = "$execPrefix $execCommand"
+
             }
-            $arguments = $execPrefix,"$execCommand"
         }
         elseif ($executor -eq "powershell") {
             $execCommand = $finalCommand -replace "`"", "`\`"`""

--- a/Private/Invoke-Process.ps1
+++ b/Private/Invoke-Process.ps1
@@ -8,7 +8,7 @@ function Invoke-Process {
         [string]$FileName = "PowerShell.exe",
 
         [Parameter(Mandatory = $false, Position = 1)]
-        [string]$Arguments = "",
+        [string[]]$Arguments = "",
         
         [Parameter(Mandatory = $false, Position = 3)]
         [Int]$TimeoutSeconds = 120,
@@ -46,8 +46,6 @@ function Invoke-Process {
                 $process.Start() > $null
                 $process.BeginOutputReadLine()
                 $process.BeginErrorReadLine()
-                $StdIn = $process.StandardInput
-                $StdIn.Close()
                 # wait for complete
                 $Timeout = [System.TimeSpan]::FromSeconds(($TimeoutSeconds))
                 $isTimeout = $false
@@ -138,7 +136,7 @@ function Invoke-Process {
                 [string]$FileName,
                 
                 [parameter(Mandatory = $false)]
-                [string]$Arguments,
+                [string[]]$Arguments,
                 
                 [parameter(Mandatory = $false)]
                 [string]$WorkingDirectory
@@ -150,7 +148,6 @@ function Invoke-Process {
             $psi.UseShellExecute = $false
             $psi.RedirectStandardOutput = $true
             $psi.RedirectStandardError = $true
-            $psi.RedirectStandardInput = $true
             $psi.FileName = $FileName
             $psi.Arguments+= $Arguments
             $psi.WorkingDirectory = $WorkingDirectory

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -207,7 +207,7 @@ function Invoke-AtomicTest {
                 $ShortTestNumbers = $AtomicTechniqueParams[-1]
             }
 
-            if ($TestNumbers -eq $null -and $ShortTestNumbers -ne $null) {
+            if ($null -eq $TestNumbers -and $null -ne $ShortTestNumbers) {
                 $TestNumbers = $ShortTestNumbers -split ','
             }
             
@@ -222,15 +222,15 @@ function Invoke-AtomicTest {
                 $commandLine = "$commandLine -ShowDetailsBrief $ShowDetailsBrief"
             }
 
-            if ($TestNumbers -ne $null) {
+            if ($null -ne $TestNumbers) {
                 $commandLine = "$commandLine -TestNumbers $TestNumbers"
             }
 
-            if ($TestNames -ne $null) {
+            if ($null -ne $TestNames) {
                 $commandLine = "$commandLine -TestNames $TestNames"
             }
 
-            if ($TestGuids -ne $null) {
+            if ($null -ne $TestGuids) {
                 $commandLine = "$commandLine -TestGuids $TestGuids"
             }
 
@@ -285,7 +285,7 @@ function Invoke-AtomicTest {
                 $commandLine = "$commandLine -KeepStdOutStdErrFiles $KeepStdOutStdErrFiles"
             }
 
-            if ($LoggingModule -ne $null) {
+            if ($null -ne $LoggingModule) {
                 $commandLine = "$commandLine -LoggingModule $LoggingModule"
             }
 
@@ -368,7 +368,7 @@ function Invoke-AtomicTest {
 
                     $testCount++
                     
-                    if (($ShowDetails -or $ShowDetailsBrief) -and -not $anyOS) {
+                    if (-not $anyOS) {
                         if ( -not $(Platform-IncludesCloud) -and -Not $test.supported_platforms.Contains($executionPlatform) ) {
                             Write-Verbose -Message "Unable to run non-$executionPlatform tests"
                             continue


### PR DESCRIPTION
This PR introduces a "-PauseBetweenAtomics" option to be used with "Invoke-AtomicRunner -ListOfAtomics" where you specify the number of seconds to pause between executions. If you specify zero, you will be prompted to press any key to run the next atomic.

This PR has an internal improvement to pass arguments as an array of strings instead of a single string which avoids problems of quoting double quotes inside of double quotes.

Fixes an issue introduced with the "-anyOS" PR where atomics that don't apply to the given OS are being invoked. For example, invoking T1016 on linux would attempt to run all of the atomics even though only one applies to linux.

Also, not redirecting stdin during atomic execution because the redirected input wasn't being used anywhere and was breaking some atomics (such as those that use ADFind)

Testing on Windows and Linux