### PR TITLE
Update Syslog-ExecutionLogger.psm1

### DIFF
--- a/Public/Syslog-ExecutionLogger.psm1
+++ b/Public/Syslog-ExecutionLogger.psm1
@@ -25,7 +25,7 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
     
     # send syslog message if a syslog server is defined in Public/config.ps1
     if ([bool]$artConfig.syslogServer -and [bool]$artConfig.syslogPort) {
-        $jsonMsg = $msg | ConvertTo-Json
+        $jsonMsg = $msg | ConvertTo-Json -Compress
         Send-SyslogMessage -Server $artConfig.syslogServer -Port $artConfig.syslogPort -Message $jsonMsg -Severity "Informational" -Facility "daemon" -Transport $artConfig.syslogProtocol
     }
 }


### PR DESCRIPTION
Most Log Collectors expects single line values. So omitting whitespace in Syslog-ExecutionLogger