### PR TITLE
dedicated cleanup task for runner

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -37,12 +37,14 @@ function Invoke-AtomicRunner {
         [ValidateRange(0, [int]::MaxValue)]
         [int] $PauseBetweenAtomics,
 
+        [parameter(Mandatory = $false)]
+        [switch] $scheduledTaskCleanup,
+
         [Parameter(Mandatory = $false, ValueFromRemainingArguments = $true)]
         $OtherArgs
     )
     Begin { }
     Process {       
-
         function Get-GuidFromHostName( $basehostname ) {
             $guid = [System.Net.Dns]::GetHostName() -replace $($basehostname + "-"), ""
 
@@ -181,6 +183,7 @@ function Invoke-AtomicRunner {
         $htvars.Remove('OtherArgs') | Out-Null
         $htvars.Remove('Cleanup') | Out-Null
         $htvars.Remove('PauseBetweenAtomics') | Out-Null
+        $htvars.Remove('scheduledTaskCleanup') | Out-Null
 
         $schedule = Get-Schedule $listOfAtomics
         # If the schedule is empty, end process
@@ -221,11 +224,14 @@ function Invoke-AtomicRunner {
             }
 
             if ($null -ne $tr) {
-                Invoke-AtomicTestFromScheduleRow $tr
-                Write-Host -Fore cyan "Sleeping for $SleepTillCleanup seconds before cleaning up"; Start-Sleep -Seconds $SleepTillCleanup
-                
-                # Cleanup after running test
-                Invoke-AtomicTestFromScheduleRow $tr $true
+                if (-not $scheduledTaskCleanup) {
+                    Invoke-AtomicTestFromScheduleRow $tr
+                }
+                else {
+                    # Cleanup after running test
+                    Write-Host -Fore cyan "Sleeping for $SleepTillCleanup seconds before cleaning up for $($tr.Technique) $($tr.auto_generated_guid) "; Start-Sleep -Seconds $SleepTillCleanup
+                    Invoke-AtomicTestFromScheduleRow $tr $true
+                }
             }
             else {
                 LogRunnerMsg "Could not find Test: $guid in schedule. Please update schedule to run this test."

--- a/Public/Invoke-KickoffAtomicRunner.ps1
+++ b/Public/Invoke-KickoffAtomicRunner.ps1
@@ -1,5 +1,10 @@
 function Invoke-KickoffAtomicRunner {
 
+    Param(
+        [parameter(Mandatory = $false, Position = 0)]
+        [switch] $scheduledTaskCleanup
+    )
+
     #log rotation function
     function Rotate-Log {
         Param ($log, $max_filesize, $max_age)
@@ -45,10 +50,10 @@ function Invoke-KickoffAtomicRunner {
 
     # Invoke the Runner Script
     if ($artConfig.debug) {
-        Invoke-AtomicRunner *>> $all_log_file
+        Invoke-AtomicRunner -scheduledTaskCleanup:$scheduledTaskCleanup *>> $all_log_file
     }
     else {
-        Invoke-AtomicRunner
+        Invoke-AtomicRunner -scheduledTaskCleanup:$scheduledTaskCleanup
     }
 }
 

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -68,7 +68,7 @@ function Invoke-SetupAtomicRunner {
         $task = New-ScheduledTask -Action $taskAction -Principal $taskPrincipal -Trigger $triggers -Description "A task that runs 1 minute or later after boot to start the atomic test runner script"
         # setup scheduled task that will start the runner cleanup task after restart
         $taskName2 = "KickOff-AtomicRunnerScheduledTask"
-        Unregister-ScheduledTask $taskName -confirm:$false -ErrorAction Ignore
+        Unregister-ScheduledTask $taskName2 -confirm:$false -ErrorAction Ignore
         $taskAction2 = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-exec bypass -Command Invoke-KickoffAtomicRunner -scheduledTaskCleanup"
         $taskPrincipal = New-ScheduledTaskPrincipal -UserId $artConfig.user
         $task2 = New-ScheduledTask -Action $taskAction2 -Principal $taskPrincipal -Trigger $triggers -Description "A task that runs 1 minute or later after boot to start the atomic test runner cleanup script"


### PR DESCRIPTION
This is an update to the Invoke-AtomicRunner code that will use two different scheduled tasks, one to run the atomic and one to run the cleanup. This is because in some cases, AV kills the original process due to the atomic it is running, which means the cleanup and reboot actions never happen and the runner stops running things. By using two different scheduled tasks (and hence two different processes) we can avoid this issue and keep things running

Note: You will need to rerun Invoke-SetupAtomicRunner to get the new schedule task after this update