### PR TITLE
Get-PreferredIPAddress MacOS fix.

### DIFF
--- a/Public/Get-PreferredIPAddress.ps1
+++ b/Public/Get-PreferredIPAddress.ps1
@@ -3,7 +3,7 @@ function Get-PreferredIPAddress($isWindows) {
         return (Get-NetIPAddress | Where-Object { $_.PrefixOrigin -ne "WellKnown" }).IPAddress
     }
     elseif ($IsMacOS) {
-        return bash -c "ifconfig -l | xargs -n1 ipconfig getifaddr"
+        return /sbin/ifconfig -l | /usr/bin/xargs -n1 /usr/sbin/ipconfig getifaddr
     }
     elseif ($IsLinux) {
         return ip -4 -br addr show | sed -n -e 's/^.*UP\s* //p' | cut -d "/" -f 1

--- a/Public/Get-PreferredIPAddress.ps1
+++ b/Public/Get-PreferredIPAddress.ps1
@@ -3,7 +3,7 @@ function Get-PreferredIPAddress($isWindows) {
         return (Get-NetIPAddress | Where-Object { $_.PrefixOrigin -ne "WellKnown" }).IPAddress
     }
     elseif ($IsMacOS) {
-        return ifconfig -l | xargs -n1 ipconfig getifaddr
+        return bash -c "ifconfig -l | xargs -n1 ipconfig getifaddr"
     }
     elseif ($IsLinux) {
         return ip -4 -br addr show | sed -n -e 's/^.*UP\s* //p' | cut -d "/" -f 1


### PR DESCRIPTION
reverted bash -c option in favor of switching to using full binary paths to prevent "command not found" error from occurring when pulling IP information from MacOS.

Tested on MacOS:

Version: 13.2.1
Build: 22D68