### PR TITLE
Atomic sudo

### DIFF
--- a/Invoke-AtomicRedTeam.psd1
+++ b/Invoke-AtomicRedTeam.psd1
@@ -41,6 +41,7 @@
         'New-AtomicTestDependency',
         'Start-AtomicGUI',
         'Stop-AtomicGUI',
+        'Set-Sudo'
         'Invoke-SetupAtomicRunner',
         'Invoke-GenerateNewSchedule',
         'Invoke-RefreshExistingSchedule',

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -1,10 +1,15 @@
-function Invoke-ExecuteCommand ($finalCommand, $executor, $executionPlatform, $TimeoutSeconds, $session = $null, $interactive) {
+function Invoke-ExecuteCommand ($finalCommand, $executor, $elevationreq, $can_sudo, $executionPlatform, $TimeoutSeconds, $session = $null, $interactive) {
     $null = @(
         if ($null -eq $finalCommand) { return 0 }
         $finalCommand = $finalCommand.trim()
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
-            $execPrefix = "-c"
+            if (($executor -eq "sh" -or $executor -eq "bash") -and ($elevationreq -eq $true) -and ($can_sudo -eq $true)) {
+                $execPrefix = "-c sudo"
+            }
+            else {
+                $execPrefix = "-c"
+            }
             $execExe = $executor
             if ($executor -eq "command_prompt") {
                 $execPrefix = "/c";

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -5,12 +5,14 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $elevationreq, $can_su
         Write-Verbose -Message 'Invoking Atomic Tests using defined executor'
         if ($executor -eq "command_prompt" -or $executor -eq "sh" -or $executor -eq "bash") {
             if (($executor -eq "sh" -or $executor -eq "bash") -and ($elevationreq -eq $true) -and ($can_sudo -eq $true)) {
-                $execPrefix = "-c sudo"
+                $execExe = "$(which sudo)"
+                $execPrefix = "$(which $executor) -c"
             }
             else {
+                $execExe = $executor
                 $execPrefix = "-c"
             }
-            $execExe = $executor
+            
             if ($executor -eq "command_prompt") {
                 $execPrefix = "/c";
                 $execExe = "cmd.exe";
@@ -18,6 +20,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $elevationreq, $can_su
                 $arguments = $execPrefix, "$execCommand"
             }
             else {
+                $execExe = $executor
                 $finalCommand = $finalCommand -replace "[\\](?!;)", "`\$&"
                 $finalCommand = $finalCommand -replace "[`"]", "`\$&"
                 $execCommand = $finalCommand -replace "(?<!;)\n", "; "

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -12,7 +12,7 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $elevationreq, $can_su
                 $execExe = $executor
                 $execPrefix = "-c"
             }
-            
+
             if ($executor -eq "command_prompt") {
                 $execPrefix = "/c";
                 $execExe = "cmd.exe";

--- a/Private/Invoke-ExecuteCommand.ps1
+++ b/Private/Invoke-ExecuteCommand.ps1
@@ -20,7 +20,6 @@ function Invoke-ExecuteCommand ($finalCommand, $executor, $elevationreq, $can_su
                 $arguments = $execPrefix, "$execCommand"
             }
             else {
-                $execExe = $executor
                 $finalCommand = $finalCommand -replace "[\\](?!;)", "`\$&"
                 $finalCommand = $finalCommand -replace "[`"]", "`\$&"
                 $execCommand = $finalCommand -replace "(?<!;)\n", "; "

--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -92,8 +92,13 @@ function Invoke-AtomicRunner {
                 LogRunnerMsg "exiting script because $($artConfig.stopFile) exists"
                 exit
             }
-
             if ($IsLinux) {
+                # Check if linux Host can use sudo without a password.
+                $can_sudo = Set-Sudo($false)
+                if($can_sudo){
+                    if ($shouldRename) { Invoke-Expression $("sudo hostnamectl set-hostname $newHostName") }
+                    Invoke-Expression $("sudo shutdown -r now")
+                }
                 if ($shouldRename) { Invoke-Expression $("hostnamectl set-hostname $newHostName") }
                 Invoke-Expression $("shutdown -r now")
             }

--- a/Public/Invoke-AtomicTest.ps1
+++ b/Public/Invoke-AtomicTest.ps1
@@ -431,7 +431,7 @@ function Invoke-AtomicTest {
 
                     # Check if linux Host can use sudo without a password.
                     $can_sudo = Set-Sudo($false)
-                    
+
                     if ($CheckPrereqs) {
                         Write-KeyValue "CheckPrereq's for: " $testId
                         $failureReasons = Invoke-CheckPrereqs $test $isElevated $executionPlatform $InputArgs $PathToPayloads $TimeoutSeconds $session

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -99,7 +99,7 @@ function Invoke-SetupAtomicRunner {
         $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
         if ($null -eq $exists -and $can_sudo -eq $true) {
-            $(bash -c 'sudo echo "$job" >> /etc/crontab')
+            $(echo "$job" | sudo tee -a /etc/crontab)
             write-host "setting cronjob"
         }
         elseif ($null -eq $exists -and $can_sudo -eq $false) {

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -114,7 +114,8 @@ function Invoke-SetupAtomicRunner {
     # Add Import-Module statement to the PowerShell profile
     $root = Split-Path $PSScriptRoot -Parent
     if($IsLinux -or $IsMacOS){
-        touch $root
+        mkdir (Split-Path $PROFILE)
+        touch $PROFILE
     }
     $pathToPSD1 = Join-Path $root "Invoke-AtomicRedTeam.psd1"
     $importStatement = "Import-Module ""$pathToPSD1"" -Force"

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -99,7 +99,7 @@ function Invoke-SetupAtomicRunner {
         $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
         if ($null -eq $exists -and $can_sudo -eq $true) {
-            $(echo "$job" | sudo tee -a /etc/crontab)
+            $(Write-Output "$job" | sudo tee -a /etc/crontab)
             write-host "setting cronjob"
         }
         elseif ($null -eq $exists -and $can_sudo -eq $false) {

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -12,7 +12,13 @@ function Invoke-SetupAtomicRunner {
     }
     else {
         # linux and macos check - doesn't auto-elevate
-        if ((id -u) -ne 0 ) {
+        # Check if current user has passwordless sudo privleges. If not, attempt to configure it for current user.
+        $can_sudo = Set-Sudo($true)
+        if ($can_sudo -eq $true -and (sudo id -u) -ne 0 ) {
+            Throw "You must run the Invoke-SetupAtomicRunner script as root"
+            exit
+        }
+        elseif ($can_sudo -eq $false -and (id -u) -ne 0 ) {
             Throw "You must run the Invoke-SetupAtomicRunner script as root"
             exit
         }
@@ -87,8 +93,6 @@ function Invoke-SetupAtomicRunner {
     }
     else {
 
-        # Check if current user has passwordless sudo privleges. If not, attempt to configure it for current user.
-        $can_sudo = Set-Sudo($true)
         # sets cronjob string using basepath from config.ps1
         $pwshPath = which pwsh
         $job = "@reboot $env:USER sleep 60;$pwshPath -Command Invoke-KickoffAtomicRunner"

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -86,9 +86,12 @@ function Invoke-SetupAtomicRunner {
         }
     }
     else {
+
+        # Check if current user has passwordless sudo privleges. If not configure it for current user.
+        Set-Sudo
         # sets cronjob string using basepath from config.ps1
         $pwshPath = which pwsh
-        $job = "@reboot root sleep 60;$pwshPath -Command Invoke-KickoffAtomicRunner"
+        $job = "@reboot $env:USER sleep 60;$pwshPath -Command Invoke-KickoffAtomicRunner"
         $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
         if ($null -eq $exists) {

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -99,7 +99,7 @@ function Invoke-SetupAtomicRunner {
         $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
         if ($null -eq $exists -and $can_sudo -eq $true) {
-            $(sudo cat "$job" >> /etc/crontab)
+            $(bash -c 'sudo echo "$job" >> /etc/crontab')
             write-host "setting cronjob"
         }
         elseif ($null -eq $exists -and $can_sudo -eq $false) {
@@ -113,6 +113,9 @@ function Invoke-SetupAtomicRunner {
 
     # Add Import-Module statement to the PowerShell profile
     $root = Split-Path $PSScriptRoot -Parent
+    if($IsLinux -or $IsMacOS){
+        touch $root
+    }
     $pathToPSD1 = Join-Path $root "Invoke-AtomicRedTeam.psd1"
     $importStatement = "Import-Module ""$pathToPSD1"" -Force"
     New-Item $PROFILE -ErrorAction Ignore

--- a/Public/Invoke-SetupAtomicRunner.ps1
+++ b/Public/Invoke-SetupAtomicRunner.ps1
@@ -87,17 +87,21 @@ function Invoke-SetupAtomicRunner {
     }
     else {
 
-        # Check if current user has passwordless sudo privleges. If not configure it for current user.
-        Set-Sudo
+        # Check if current user has passwordless sudo privleges. If not, attempt to configure it for current user.
+        $can_sudo = Set-Sudo($true)
         # sets cronjob string using basepath from config.ps1
         $pwshPath = which pwsh
         $job = "@reboot $env:USER sleep 60;$pwshPath -Command Invoke-KickoffAtomicRunner"
         $exists = cat /etc/crontab | Select-String -Quiet "KickoffAtomicRunner"
         #checks if the Kickoff-AtomicRunner job exists. If not appends it to the system crontab.
-        if ($null -eq $exists) {
-            $(Write-Output "$job" >> /etc/crontab)
+        if ($null -eq $exists -and $can_sudo -eq $true) {
+            $(sudo cat "$job" >> /etc/crontab)
             write-host "setting cronjob"
         }
+        elseif ($null -eq $exists -and $can_sudo -eq $false) {
+            $(Write-Output "$job" >> /etc/crontab)
+            write-host "setting cronjob"
+            }
         else {
             write-host "cronjob already exists"
         }

--- a/Public/Set-Sudo.ps1
+++ b/Public/Set-Sudo.ps1
@@ -1,4 +1,4 @@
-function Set-Sudo {
+function Set-Sudo ($set_sudo) {
 
     $ErrorActionPreference = "Stop"
     $env:SUDO_ASKPASS="/bin/false"
@@ -7,18 +7,25 @@ function Set-Sudo {
         if ((sudo -A whoami) -and ((sudo grep -r $env:USER /etc/sudoers | grep NOPASSWD:ALL) -or (sudo grep -r $env:USER /etc/sudoers.d | grep NOPASSWD:ALL))){
             
             Write-Host "Passwordless logon already configured.`n"
+            $nopassword_enabled = $true
 
         }
-        else{
+        elseif ($set_sudo -eq $true){
             
             Write-Host "Configuring Passwordless logon...`n"
             echo "$env:USER ALL=(ALL) NOPASSWD:ALL" > /tmp/90-$env:USER-sudo-access
             sudo install -m 440 /tmp/90-$env:USER-sudo-access /etc/sudoers.d/90-$env:USER-sudo-access
             rm -f /tmp/90-$env:USER-sudo-access
+            $nopassword_enabled = $true
+        }
+        else {
+            write-host "Host not configured for passwordless logon"
+            $nopassword_enabled = $false
         }
     }
     catch {
         write-host "Error configuring passwordless logon"
+        $nopassword_enabled = $false
     }
-
+return $nopassword_enabled
 }

--- a/Public/Set-Sudo.ps1
+++ b/Public/Set-Sudo.ps1
@@ -5,8 +5,10 @@ function Set-Sudo ($set_sudo) {
 
     try {
         if ((sudo -A whoami) -and ((sudo grep -r $env:USER /etc/sudoers | grep NOPASSWD:ALL) -or (sudo grep -r $env:USER /etc/sudoers.d | grep NOPASSWD:ALL))){
-            
-            Write-Host "Passwordless logon already configured.`n"
+           
+            if($set_sudo){
+                Write-Host "Passwordless logon already configured.`n"
+            }
             $nopassword_enabled = $true
 
         }

--- a/Public/Set-Sudo.ps1
+++ b/Public/Set-Sudo.ps1
@@ -1,0 +1,24 @@
+function Set-Sudo {
+
+    $ErrorActionPreference = "Stop"
+    $env:SUDO_ASKPASS="/bin/false"
+
+    try {
+        if ((sudo -A whoami) -and ((sudo grep -r $env:USER /etc/sudoers | grep NOPASSWD:ALL) -or (sudo grep -r $env:USER /etc/sudoers.d | grep NOPASSWD:ALL))){
+            
+            Write-Host "Passwordless logon already configured.`n"
+
+        }
+        else{
+            
+            Write-Host "Configuring Passwordless logon...`n"
+            echo "$env:USER ALL=(ALL) NOPASSWD:ALL" > /tmp/90-$env:USER-sudo-access
+            sudo install -m 440 /tmp/90-$env:USER-sudo-access /etc/sudoers.d/90-$env:USER-sudo-access
+            rm -f /tmp/90-$env:USER-sudo-access
+        }
+    }
+    catch {
+        write-host "Error configuring passwordless logon"
+    }
+
+}

--- a/Public/Set-Sudo.ps1
+++ b/Public/Set-Sudo.ps1
@@ -5,7 +5,7 @@ function Set-Sudo ($set_sudo) {
 
     try {
         if ((sudo -A whoami) -and ((sudo grep -r $env:USER /etc/sudoers | grep NOPASSWD:ALL) -or (sudo grep -r $env:USER /etc/sudoers.d | grep NOPASSWD:ALL))){
-           
+
             if($set_sudo){
                 Write-Host "Passwordless logon already configured.`n"
             }
@@ -13,9 +13,9 @@ function Set-Sudo ($set_sudo) {
 
         }
         elseif ($set_sudo -eq $true){
-            
+
             Write-Host "Configuring Passwordless logon...`n"
-            echo "$env:USER ALL=(ALL) NOPASSWD:ALL" > /tmp/90-$env:USER-sudo-access
+            Write-Output "$env:USER ALL=(ALL) NOPASSWD:ALL" > /tmp/90-$env:USER-sudo-access
             sudo install -m 440 /tmp/90-$env:USER-sudo-access /etc/sudoers.d/90-$env:USER-sudo-access
             rm -f /tmp/90-$env:USER-sudo-access
             $nopassword_enabled = $true


### PR DESCRIPTION
The changes made below are intended to provide a new option when installing the atomic runner code on a *Nix machine that will allow it to be configured to use a different user account other than root. That account will require sudo access.

The code updates adds checks for this configuration, and prepends the sudo command before commands that require it. To make this not require a password, the "set-sudo" script will create a sudo config to allow passwordless sudo for the account configured during the invoke-SetupAtomicRunner script. It will prompt the user once for the password and then configure the account to no longer require it for sudo permission.

This optional config will only trigger if you run the Invoke-SetupAtomicRunner as a not-root account with sudo privileged. If run as root, then the normal behavior will be preserved.