### PR TITLE
Adding warning for unsupported platforms instead of errors

### DIFF
--- a/Public/Get-AtomicTechnique.ps1
+++ b/Public/Get-AtomicTechnique.ps1
@@ -228,8 +228,7 @@ filter Get-AtomicTechnique {
 
             foreach ($SupportedPlatform in $AtomicTest['supported_platforms']) {
                 if ($ValidSupportedPlatforms -cnotcontains $SupportedPlatform) {
-                    Write-Error "$ErrorStringPrefix[Atomic test name: $($AtomicTestInstance.name)] 'atomic_tests[$i].supported_platforms': '$SupportedPlatform' must be one of the following: $($ValidSupportedPlatforms -join ', ')."
-                    return
+                    Write-Warning "$ErrorStringPrefix[Atomic test name: $($AtomicTestInstance.name)] 'atomic_tests[$i].supported_platforms': '$SupportedPlatform' must be one of the following: $($ValidSupportedPlatforms -join ', ')."
                 }
             }
 


### PR DESCRIPTION
If the users have private atomic tests for proprietary OS, this PR gives them the functionality to execute those tests without running into an error. 
 
`supported_platforms` is not used in the `Invoke-AtomicTest` apart from the cloud tests(for terraform related things). So these changes shouldn't cause any issues. 

Fixes #196 