### PR TITLE
add logfile name to runner config

### DIFF
--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -34,6 +34,7 @@ $artConfig = [PSCustomObject]@{
   # [optional] logfile filename configs
   logFolder                  = "AtomicRunner-Logs"
   timeLocal                  = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
+  logFileName                = "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv"
 
   # amsi bypass script block (applies to Windows only)
   absb                       = $null
@@ -95,7 +96,7 @@ $scriptParam = @{
   MemberType  = "ScriptProperty"
   InputObject = $artConfig
   Name        = "execLogPath"
-  Value       = { Join-Path $artConfig.atomicLogsPath "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv" }
+  Value       = { Join-Path $artConfig.atomicLogsPath $artConfig.logFileName }
 }
 Add-Member @scriptParam
 


### PR DESCRIPTION
Allow specification of logfile name when using Invoke-AtomicRunner so that you can specify a JSON file to be used with the ATTIRE logger. Otherwise, the code assumes CSV.