### PR TITLE
Update Attire-ExecutionLogger.psm1

### DIFF
--- a/Public/Attire-ExecutionLogger.psm1
+++ b/Public/Attire-ExecutionLogger.psm1
@@ -82,6 +82,9 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
         'time-stop'  = $stopTime
         'executor'   = $testExecutor
         'command'    = $command
+        'process-id' = $res.ProcessId
+        'exit-code'  = $res.ExitCode
+        'is-timeout' = $res.IsTimeout
         'output'     = @()
     }
 


### PR DESCRIPTION
“Process ID”, ‘Exit Code’ and ‘Is Timeout’ values have been added to Attire-Logging. The reason for this addition is to easily find the attacks triggered by “Invoke-Atomic” with the detection rules on SIEM.