### PR TITLE
Update module version in Github Actions to avoid future errors

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: Update Module Version
+        run: |
+          sed -i "s/ModuleVersion     = '.*'/ModuleVersion     = '${{ github.event.release.tag_name }}'/g" Invoke-AtomicRedTeam.psd1
       - name: publishing
         run: |
           Install-Module -Name powershell-yaml -Force

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Update Module Version
         run: |
-          sed -i "s/ModuleVersion     = '.*'/ModuleVersion     = '${{ github.event.release.tag_name }}'/g" Invoke-AtomicRedTeam.psd1
+          sed -i "s/ModuleVersion     = '.*'/ModuleVersion     = '${{ github.event.release.tag_name | replace('v', '') }}'/g" Invoke-AtomicRedTeam.psd1
       - name: publishing
         run: |
           Install-Module -Name powershell-yaml -Force


### PR DESCRIPTION
Right now, the ModuleVersion doesn't get autoupdated and we have to manually update the version before each release. This should help us with replacing the current version from the GH release tag. 