### PR TITLE
Improvements to Get-NewSchedule

### DIFF
--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -46,8 +46,8 @@ function Get-NewSchedule() {
         Write-Verbose "Private Atomics Folder not Found $($artConfig.PathToPrivateAtomicsFolder)"
     }
     $AllAtomicTests = New-Object System.Collections.ArrayList
-    try { $AllAtomicTests.AddRange($publicAtomics) }catch {}
-    try { $AllAtomicTests.AddRange($privateAtomics) }catch {}
+    try { $AllAtomicTests.AddRange(@($publicAtomics)) } catch { Write-Error $_ }
+    try { $AllAtomicTests.AddRange(@($privateAtomics)) } catch { Write-Error $_ }
     return $AllAtomicTests
 }
 


### PR DESCRIPTION
When generating a new schedule using Invoke-GenerateNewSchedule there exists an edge case when only 1 atomic test is found in the PrivateAtomics folder.
This causes the try-catch block to catch the error and completely swallow it. This is not very transparent and can be improved by writing the error instead.
Furthermore, the proper fix is to wrap the received object from the Loop function in an array before adding them to the AllAtomicTests arraylist object. This fixes the issue.

How to reproduce:
1. Create a single atomic test in the PrivateAtomics folder
2. Run Invoke-GenerateNewSchedule

Before (with errors visible):
```
PS C:\Users\Mattis> Invoke-GenerateNewSchedule
Generating new schedule: C:\AtomicRedTeam\AtomicRunner\AtomicRunnerSchedule.csv
Get-NewSchedule : Cannot convert argument "c", with value: "@{Order=; Technique=T1027; TestName=Obfuscated Command in Windows Command Prompt;
auto_generated_guid=b5d35ae3-c431-410e-a556-fdcf66c642b6; supported_platforms=windows; TimeoutSeconds=120; InputArgs=; AtomicsFolder=Private; enabled=False;
notes=}", for "AddRange" to type "System.Collections.ICollection": "Cannot convert the "@{Order=; Technique=T1027; TestName=Obfuscated Command in Windows
Command Prompt; auto_generated_guid=b5d35ae3-c431-410e-a556-fdcf66c642b6; supported_platforms=windows; TimeoutSeconds=120; InputArgs=; AtomicsFolder=Private;
enabled=False; notes=}" value of type "System.Management.Automation.PSCustomObject" to type "System.Collections.ICollection"."
At C:\AtomicRedTeam\invoke-atomicredteam\Public\Invoke-RunnerScheduleMethods.ps1:141 char:17
+     $schedule = Get-NewSchedule
+                 ~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Get-NewSchedule

Schedule written to C:\AtomicRedTeam\AtomicRunner\AtomicRunnerSchedule.csv
```
The mentioned atomic test does not show up in the csv file afterwards.

After:
```
PS C:\Users\Mattis> Invoke-GenerateNewSchedule
Generating new schedule: C:\AtomicRedTeam\AtomicRunner\AtomicRunnerSchedule.csv
Schedule written to C:\AtomicRedTeam\AtomicRunner\AtomicRunnerSchedule.csv
```