### PR TITLE
Change the workflow process to check file integrity and forks

### DIFF
--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout PR branch with history
+      - name: Checkout PR branch with full history
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # allow accurate diffs
+          fetch-depth: 0 # full history for accurate diffing
       - name: Add upstream remote and fetch base branch
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
@@ -43,12 +43,14 @@ jobs:
             echo "scripts_modified=false" >> $GITHUB_OUTPUT
           fi
       - name: Decide whether to run scripts
-        id: check
+        id: safecheck
         run: |
-          if [ "${{ steps.forkcheck.outputs.is_fork }}" = "true" ] && [ "${{ steps.filecheck.outputs.scripts_modified }}" = "true" ]; then
-            echo "safe=false" >> $GITHUB_OUTPUT
-          else
+          if [ "${{ steps.filecheck.outputs.scripts_modified }}" = "false" ]; then
             echo "safe=true" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.forkcheck.outputs.is_fork }}" = "false" ]; then
+            echo "safe=true" >> $GITHUB_OUTPUT
+          else
+            echo "safe=false" >> $GITHUB_OUTPUT
           fi
       - name: Execute install scripts
         if: steps.safecheck.outputs.safe == 'true'

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout PR branch with history
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2 # allow accurate diffs
+          fetch-depth: 0 # allow accurate diffs
       - name: Add upstream remote and fetch base branch
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -57,8 +57,8 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "Running install scripts from trusted context"
-          powershell -ExecutionPolicy Bypass -File ./install-atomicredteam.ps1
-          powershell -ExecutionPolicy Bypass -File ./install-atomicsfolder.ps1
+          ./install-atomicredteam.ps1
+          ./install-atomicsfolder.ps1
       - name: Skip script execution
         if: steps.safecheck.outputs.safe != 'true'
         run: |

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -2,10 +2,10 @@ name: Installation Check
 on:
   pull_request:
     branches:
-      - main
+      - master
   push:
     branches:
-      - main
+      - master
 permissions:
   contents: read
 jobs:
@@ -23,7 +23,7 @@ jobs:
       - name: Add upstream remote and fetch base branch
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream main
+          git fetch upstream master
       - name: Detect fork
         id: forkcheck
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Check if install scripts were modified
         id: filecheck
         run: |
-          MODIFIED=$(git diff --name-only upstream/main HEAD)
+          MODIFIED=$(git diff --name-only upstream/master HEAD)
           echo "$MODIFIED"
           if echo "$MODIFIED" | grep -qE '^install-atomicredteam\.ps1$|^install-atomicsfolder\.ps1$'; then
             echo "scripts_modified=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -1,22 +1,63 @@
-name: Check installation
-on: pull_request
+name: Installation Check
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
 jobs:
-  install-invoke:
-    name: Install Invoke-Atomic
+  install-check:
+    name: Secure Install Check
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 3
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Install Invoke-AtomicRedTeam
+      - name: Checkout PR branch with history
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2 # allow accurate diffs
+      - name: Add upstream remote and fetch base branch
+        run: |
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream main
+      - name: Detect fork
+        id: forkcheck
+        run: |
+          if [ "${{ github.repository }}" != "${{ github.event.pull_request.head.repo.full_name }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Check if install scripts were modified
+        id: filecheck
+        run: |
+          MODIFIED=$(git diff --name-only upstream/main HEAD)
+          echo "$MODIFIED"
+          if echo "$MODIFIED" | grep -qE '^install-atomicredteam\.ps1$|^install-atomicsfolder\.ps1$'; then
+            echo "scripts_modified=true" >> $GITHUB_OUTPUT
+          else
+            echo "scripts_modified=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Decide whether to run scripts
+        id: check
+        run: |
+          if [ "${{ steps.forkcheck.outputs.is_fork }}" = "true" ] && [ "${{ steps.filecheck.outputs.scripts_modified }}" = "true" ]; then
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Execute install scripts
+        if: steps.safecheck.outputs.safe == 'true'
         shell: pwsh
         run: |
-          IEX (IWR 'https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.ref }}/install-atomicredteam.ps1' -UseBasicParsing);
-          Install-AtomicRedTeam -RepoOwner "${{ github.event.pull_request.head.repo.owner.login }}" -Branch "${{ github.event.pull_request.head.ref }}" -Force
-          if($error.contains("Installation of AtomicRedTeam Failed")){
-            exit 1
-          }
-          IEX (IWR 'https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.ref }}/install-atomicsfolder.ps1' -UseBasicParsing);
-          Install-AtomicsFolder -Force
-          Invoke-AtomicTest All -ShowDetailsBrief
+          Write-Output "Running install scripts from trusted context"
+          powershell -ExecutionPolicy Bypass -File ./install-atomicredteam.ps1
+          powershell -ExecutionPolicy Bypass -File ./install-atomicsfolder.ps1
+      - name: Skip script execution
+        if: steps.safecheck.outputs.safe != 'true'
+        run: |
+          echo "::warning:: install scripts were modified in a forked PR. Skipping execution until merge."

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
 jobs:
-  install-check:
+  secure-install-check:
     name: Secure Install Check
     runs-on: ${{ matrix.os }}
     strategy:
@@ -19,21 +19,24 @@ jobs:
       - name: Checkout PR branch with full history
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # full history for accurate diffing
+          fetch-depth: 0
       - name: Add upstream remote and fetch base branch
+        shell: bash
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream master
       - name: Detect fork
         id: forkcheck
+        shell: pwsh
         run: |
-          if [ "${{ github.repository }}" != "${{ github.event.pull_request.head.repo.full_name }}" ]; then
-            echo "is_fork=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_fork=false" >> $GITHUB_OUTPUT
-          fi
+          if ("${{ github.repository }}" -ne "${{ github.event.pull_request.head.repo.full_name }}") {
+            "is_fork=true" >> $env:GITHUB_OUTPUT
+          } else {
+            "is_fork=false" >> $env:GITHUB_OUTPUT
+          }
       - name: Check if install scripts were modified
         id: filecheck
+        shell: bash
         run: |
           MODIFIED=$(git diff --name-only upstream/master HEAD)
           echo "$MODIFIED"
@@ -44,14 +47,17 @@ jobs:
           fi
       - name: Decide whether to run scripts
         id: safecheck
+        shell: pwsh
         run: |
-          if [ "${{ steps.filecheck.outputs.scripts_modified }}" = "false" ]; then
-            echo "safe=true" >> $GITHUB_OUTPUT
-          elif [ "${{ steps.forkcheck.outputs.is_fork }}" = "false" ]; then
-            echo "safe=true" >> $GITHUB_OUTPUT
-          else
-            echo "safe=false" >> $GITHUB_OUTPUT
-          fi
+          if ("${{ steps.filecheck.outputs.scripts_modified }}" -eq "false") {
+            "safe=true" >> $env:GITHUB_OUTPUT
+          } elseif ("${{ github.event_name }}" -eq "push") {
+            "safe=true" >> $env:GITHUB_OUTPUT
+          } elseif ("${{ steps.forkcheck.outputs.is_fork }}" -eq "false") {
+            "safe=true" >> $env:GITHUB_OUTPUT
+          } else {
+            "safe=false" >> $env:GITHUB_OUTPUT
+          }
       - name: Execute install scripts
         if: steps.safecheck.outputs.safe == 'true'
         shell: pwsh

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -1,71 +1,24 @@
-name: Installation Check
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
-permissions:
-  contents: read
+name: Check installation
+on: pull_request
+
 jobs:
-  secure-install-check:
-    name: Secure Install Check
+  install-invoke:
+    name: Install Invoke-Atomic
     runs-on: ${{ matrix.os }}
+    if: ${{ !contains(github.event.pull_request.changed_files, 'install-atomicredteam.ps1') && !contains(github.event.pull_request.changed_files, 'install-atomicsfolder.ps1') }}
     strategy:
+      max-parallel: 3
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Checkout PR branch with full history
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Add upstream remote and fetch base branch
-        shell: bash
-        run: |
-          git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream master
-      - name: Detect fork
-        id: forkcheck
+      - name: Install Invoke-AtomicRedTeam
         shell: pwsh
         run: |
-          if ("${{ github.repository }}" -ne "${{ github.event.pull_request.head.repo.full_name }}") {
-            "is_fork=true" >> $env:GITHUB_OUTPUT
-          } else {
-            "is_fork=false" >> $env:GITHUB_OUTPUT
+          IEX (IWR 'https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.ref }}/install-atomicredteam.ps1' -UseBasicParsing);
+          Install-AtomicRedTeam -RepoOwner "${{ github.event.pull_request.head.repo.owner.login }}" -Branch "${{ github.event.pull_request.head.ref }}" -Force
+          if($error.contains("Installation of AtomicRedTeam Failed")){
+            exit 1
           }
-      - name: Check if install scripts were modified
-        id: filecheck
-        shell: bash
-        run: |
-          MODIFIED=$(git diff --name-only upstream/master HEAD)
-          echo "$MODIFIED"
-          if echo "$MODIFIED" | grep -qE '^install-atomicredteam\.ps1$|^install-atomicsfolder\.ps1$'; then
-            echo "scripts_modified=true" >> $GITHUB_OUTPUT
-          else
-            echo "scripts_modified=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Decide whether to run scripts
-        id: safecheck
-        shell: pwsh
-        run: |
-          if ("${{ steps.filecheck.outputs.scripts_modified }}" -eq "false") {
-            "safe=true" >> $env:GITHUB_OUTPUT
-          } elseif ("${{ github.event_name }}" -eq "push") {
-            "safe=true" >> $env:GITHUB_OUTPUT
-          } elseif ("${{ steps.forkcheck.outputs.is_fork }}" -eq "false") {
-            "safe=true" >> $env:GITHUB_OUTPUT
-          } else {
-            "safe=false" >> $env:GITHUB_OUTPUT
-          }
-      - name: Execute install scripts
-        if: steps.safecheck.outputs.safe == 'true'
-        shell: pwsh
-        run: |
-          Write-Output "Running install scripts from trusted context"
-          ./install-atomicredteam.ps1
-          ./install-atomicsfolder.ps1
-      - name: Skip script execution
-        if: steps.safecheck.outputs.safe != 'true'
-        run: |
-          echo "::warning:: install scripts were modified in a forked PR. Skipping execution until merge."
+          IEX (IWR 'https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name }}/${{ github.event.pull_request.head.ref }}/install-atomicsfolder.ps1' -UseBasicParsing);
+          Install-AtomicsFolder -Force
+          Invoke-AtomicTest All -ShowDetailsBrief


### PR DESCRIPTION
Checks to see if powershell scripts were changed, and if it's a fork. Forked repos without changes to the powershell scripts will run the workflow normally. If the powershell scripts have been changed, the workflow will not run and will need to be manually checked. The filepaths of the powershell scripts are no longer assembled using the forked repo name and author variables. 