### PR TITLE
Improvement to default log filename values.

### DIFF
--- a/Public/Invoke-AtomicRunner.ps1
+++ b/Public/Invoke-AtomicRunner.ps1
@@ -49,6 +49,7 @@ function Invoke-AtomicRunner {
     )
     Begin { }
     Process {
+        $currentExecLogPath = $artConfig.execLogPath
 
         function Get-GuidFromHostName( $basehostname ) {
             $guid = [System.Net.Dns]::GetHostName() -replace $($basehostname + "-"), ""
@@ -72,10 +73,10 @@ function Invoke-AtomicRunner {
             $sc = $tr.AtomicsFolder
             #Run the Test based on if scheduleContext is 'private' or 'public'
             if (($sc -eq 'public') -or ($null -eq $sc)) {
-                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPublicAtomicsFolder @htvars -supressPathToAtomicsFolder
+                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $currentExecLogPath -PathToAtomicsFolder $artConfig.PathToPublicAtomicsFolder @htvars -supressPathToAtomicsFolder
             }
             elseif ($sc -eq 'private') {
-                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $artConfig.execLogPath -PathToAtomicsFolder $artConfig.PathToPrivateAtomicsFolder @htvars -supressPathToAtomicsFolder
+                Invoke-AtomicTest $tr.Technique -TestGuids $tr.auto_generated_guid -InputArgs $tr.InputArgs -TimeoutSeconds $tr.TimeoutSeconds -ExecutionLogPath $currentExecLogPath -PathToAtomicsFolder $artConfig.PathToPrivateAtomicsFolder @htvars -supressPathToAtomicsFolder
             }
             if ($timeToPause -gt 0) {
                 Write-Host "Sleeping for $timeToPause seconds..."

--- a/Public/Invoke-RunnerScheduleMethods.ps1
+++ b/Public/Invoke-RunnerScheduleMethods.ps1
@@ -46,8 +46,8 @@ function Get-NewSchedule() {
         Write-Verbose "Private Atomics Folder not Found $($artConfig.PathToPrivateAtomicsFolder)"
     }
     $AllAtomicTests = New-Object System.Collections.ArrayList
-    try { $AllAtomicTests.AddRange($publicAtomics) }catch {}
-    try { $AllAtomicTests.AddRange($privateAtomics) }catch {}
+    try { $AllAtomicTests.AddRange(@($publicAtomics)) } catch { Write-Error $_ }
+    try { $AllAtomicTests.AddRange(@($privateAtomics)) } catch { Write-Error $_ }
     return $AllAtomicTests
 }
 

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -46,7 +46,7 @@ $artConfig = [PSCustomObject]@{
 # For log filenames to update with the current time when they are accessed, they need to be initiated as ScriptProperty properties
 $scriptParam = @{
   MemberType  = "ScriptProperty"
-  InputObject = $PrivateConfig
+  InputObject = $artConfig
   Name        = "timeLocal"
   Value       = { (Get-Date(get-date) -uformat "%Y-%m-%d").ToString() }
 }
@@ -54,7 +54,7 @@ Add-Member @scriptParam
 
 $scriptParam = @{
   MemberType  = "ScriptProperty"
-  InputObject = $PrivateConfig
+  InputObject = $artConfig
   Name        = "logFileName"
   Value       = { "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv" }
 }

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -60,7 +60,6 @@ $scriptParam = @{
 }
 Add-Member @scriptParam
 
-
 # If you create a file called privateConfig.ps1 in the same directory as you installed Invoke-AtomicRedTeam you can overwrite any of these settings with your custom values
 $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $pathToPrivateConfig = Join-Path $root "privateConfig.ps1"

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -31,10 +31,8 @@ $artConfig = [PSCustomObject]@{
 
   verbose                    = $true; # set to true for more log output
 
-  # [optional] logfile filename configs
+  # [optional] logfile filename config
   logFolder                  = "AtomicRunner-Logs"
-  timeLocal                  = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
-  logFileName                = "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv"
 
   # amsi bypass script block (applies to Windows only)
   absb                       = $null
@@ -43,6 +41,24 @@ $artConfig = [PSCustomObject]@{
   ServiceInstallDir                 = "${ENV:windir}\System32"
 
 }
+
+# For log filenames to update with the current time when they are accessed, they need to initiated as ScriptProperty properties
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $PrivateConfig
+  Name        = "timeLocal"
+  Value       = { (Get-Date(get-date) -uformat "%Y-%m-%dT%H-%M").ToString() }
+}
+Add-Member @scriptParam
+
+$scriptParam = @{
+  MemberType  = "ScriptProperty"
+  InputObject = $PrivateConfig
+  Name        = "logFileName"
+  Value       = { "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv" }
+}
+Add-Member @scriptParam
+
 
 # If you create a file called privateConfig.ps1 in the same directory as you installed Invoke-AtomicRedTeam you can overwrite any of these settings with your custom values
 $root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -31,7 +31,7 @@ $artConfig = [PSCustomObject]@{
 
   verbose                    = $true; # set to true for more log output
 
-  # [optional] logfile filename config
+  # [optional] log location configuration
   logFolder                  = "AtomicRunner-Logs"
 
   # amsi bypass script block (applies to Windows only)
@@ -42,7 +42,8 @@ $artConfig = [PSCustomObject]@{
 
 }
 
-# For log filenames to update with the current time when they are accessed, they need to initiated as ScriptProperty properties
+# [optional] log filename configuration
+# For log filenames to update with the current time when they are accessed, they need to be initiated as ScriptProperty properties
 $scriptParam = @{
   MemberType  = "ScriptProperty"
   InputObject = $PrivateConfig

--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -48,7 +48,7 @@ $scriptParam = @{
   MemberType  = "ScriptProperty"
   InputObject = $PrivateConfig
   Name        = "timeLocal"
-  Value       = { (Get-Date(get-date) -uformat "%Y-%m-%dT%H-%M").ToString() }
+  Value       = { (Get-Date(get-date) -uformat "%Y-%m-%d").ToString() }
 }
 Add-Member @scriptParam
 


### PR DESCRIPTION
The default configuration in config.ps1 includes the following values as NoteProperties for the log filename value:
```
  timeLocal                  = (Get-Date(get-date) -uformat "%Y-%m-%d").ToString()
  logFileName                = "$($artConfig.timeLocal)`_$($artConfig.basehostname)-ExecLog.csv"
```
As `NoteProperty` objects don't update after they are initiated, they will always hold the value that they were assigned when `config.ps1` was last run (usually when the invoke-atomicredteam module was imported)

This means that `$artConfig.timeLocal` will contain the time at which the module was imported, and `$artConfig.logFileName` will simply contain "_-ExecLog.csv" as the `timeLocal` property of `$artConfig` is only initiated after the whole `$artConfig` object is initiated.

This can be fixed by importing the module a second time, as `$artConfig.logFileName` will then find the `timeLocal` property of the old `$artConfig` object, before being overwritten with a new value. But it would still just hold a static value.

Overall, this is a pretty clumsy approach. A better system would be to initiate the `timeLocal`, `logFileName` properties as `ScriptProperty` objects. A `ScriptProperty` object recalculates it's value every time it is accessed.

Furthermore, a modification to `Invoke-AtomicRunner` is necessary to ensure all tests that were run during the same invokation of the `Invoke-AtomicRunner` cmdlet end up in the same log file.

Open to feedback