### PR TITLE
Support absolute path for logFolder

### DIFF
--- a/Public/config.ps1
+++ b/Public/config.ps1
@@ -72,7 +72,13 @@ $scriptParam = @{
   MemberType  = "ScriptProperty"
   InputObject = $artConfig
   Name        = "atomicLogsPath"
-  Value       = { Join-Path $artConfig.basePath $artConfig.logFolder }
+  Value       = {
+    if (($artConfig.logFolder -match "^[A-Za-z]:\\") -or ($artConfig.logFolder -match "^/")) {
+      $artConfig.logFolder
+    } else {
+      Join-Path $artConfig.basePath $artConfig.logFolder
+    }
+  }
 }
 Add-Member @scriptParam
 


### PR DESCRIPTION
When setting up the following configurations:
```powershell
@'
$artConfig | Add-Member -Force -NotePropertyMembers @{
  LoggingModule = 'Attire-ExecutionLogger'
  logFileName = 'timestamp_atomic_output.json'
  logFolder = 'C:\AtomicRedTeam\AtomicRunner-Logs'
}
'@ | Out-File -FilePath "C:\AtomicRedTeam\privateConfig.ps1" -Encoding utf8 -Force
```
I get malformed file path.

This simple change is meant to support logFolder absolute path, if no absolute path is given then the behavior will be the same, so this is not a breaking change. 